### PR TITLE
feat: new loan limitation logic

### DIFF
--- a/.openzeppelin/unknown-2008.json
+++ b/.openzeppelin/unknown-2008.json
@@ -702,7 +702,7 @@
             "slot": "0",
             "type": "t_address",
             "contract": "LiquidityPoolAccountable",
-            "src": "src\\liquidity-pools\\LiquidityPoolAccountable.sol:41"
+            "src": "contracts\\liquidity-pools\\LiquidityPoolAccountable.sol:40"
           },
           {
             "label": "_market",
@@ -710,7 +710,7 @@
             "slot": "1",
             "type": "t_address",
             "contract": "LiquidityPoolAccountable",
-            "src": "src\\liquidity-pools\\LiquidityPoolAccountable.sol:44"
+            "src": "contracts\\liquidity-pools\\LiquidityPoolAccountable.sol:43"
           },
           {
             "label": "_borrowableBalance",
@@ -718,7 +718,7 @@
             "slot": "1",
             "type": "t_uint64",
             "contract": "LiquidityPoolAccountable",
-            "src": "src\\liquidity-pools\\LiquidityPoolAccountable.sol:47"
+            "src": "contracts\\liquidity-pools\\LiquidityPoolAccountable.sol:46"
           },
           {
             "label": "_addonsBalance",
@@ -726,7 +726,7 @@
             "slot": "2",
             "type": "t_uint64",
             "contract": "LiquidityPoolAccountable",
-            "src": "src\\liquidity-pools\\LiquidityPoolAccountable.sol:50"
+            "src": "contracts\\liquidity-pools\\LiquidityPoolAccountable.sol:49"
           },
           {
             "label": "__gap",
@@ -734,7 +734,7 @@
             "slot": "3",
             "type": "t_array(t_uint256)46_storage",
             "contract": "LiquidityPoolAccountable",
-            "src": "src\\liquidity-pools\\LiquidityPoolAccountable.sol:54"
+            "src": "contracts\\liquidity-pools\\LiquidityPoolAccountable.sol:53"
           }
         ],
         "types": {
@@ -754,7 +754,7 @@
             "label": "mapping(address => bool)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_bytes32,t_struct(RoleData)25_storage)": {
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
             "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
             "numberOfBytes": "32"
           },
@@ -763,14 +763,14 @@
             "members": [
               {
                 "label": "_roles",
-                "type": "t_mapping(t_bytes32,t_struct(RoleData)25_storage)",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
                 "offset": 0,
                 "slot": "0"
               }
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(InitializableStorage)93_storage": {
+          "t_struct(InitializableStorage)145_storage": {
             "label": "struct Initializable.InitializableStorage",
             "members": [
               {
@@ -788,7 +788,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(PausableStorage)219_storage": {
+          "t_struct(PausableStorage)291_storage": {
             "label": "struct PausableUpgradeable.PausableStorage",
             "members": [
               {
@@ -800,7 +800,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(RoleData)25_storage": {
+          "t_struct(RoleData)24_storage": {
             "label": "struct AccessControlUpgradeable.RoleData",
             "members": [
               {
@@ -846,7 +846,7 @@
             {
               "contract": "AccessControlUpgradeable",
               "label": "_roles",
-              "type": "t_mapping(t_bytes32,t_struct(RoleData)25_storage)",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
               "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61",
               "offset": 0,
               "slot": "0"
@@ -1230,7 +1230,7 @@
             "slot": "0",
             "type": "t_uint256",
             "contract": "LendingMarketStorage",
-            "src": "src\\LendingMarketStorage.sol:16"
+            "src": "contracts\\LendingMarketStorage.sol:16"
           },
           {
             "label": "_programIdCounter",
@@ -1238,15 +1238,15 @@
             "slot": "1",
             "type": "t_uint32",
             "contract": "LendingMarketStorage",
-            "src": "src\\LendingMarketStorage.sol:19"
+            "src": "contracts\\LendingMarketStorage.sol:19"
           },
           {
             "label": "_loans",
             "offset": 0,
             "slot": "2",
-            "type": "t_mapping(t_uint256,t_struct(State)6652_storage)",
+            "type": "t_mapping(t_uint256,t_struct(State)6678_storage)",
             "contract": "LendingMarketStorage",
-            "src": "src\\LendingMarketStorage.sol:22"
+            "src": "contracts\\LendingMarketStorage.sol:22"
           },
           {
             "label": "_creditLineLenders",
@@ -1254,7 +1254,7 @@
             "slot": "3",
             "type": "t_mapping(t_address,t_address)",
             "contract": "LendingMarketStorage",
-            "src": "src\\LendingMarketStorage.sol:25"
+            "src": "contracts\\LendingMarketStorage.sol:25"
           },
           {
             "label": "_liquidityPoolLenders",
@@ -1262,7 +1262,7 @@
             "slot": "4",
             "type": "t_mapping(t_address,t_address)",
             "contract": "LendingMarketStorage",
-            "src": "src\\LendingMarketStorage.sol:28"
+            "src": "contracts\\LendingMarketStorage.sol:28"
           },
           {
             "label": "_programLenders",
@@ -1270,7 +1270,7 @@
             "slot": "5",
             "type": "t_mapping(t_uint32,t_address)",
             "contract": "LendingMarketStorage",
-            "src": "src\\LendingMarketStorage.sol:31"
+            "src": "contracts\\LendingMarketStorage.sol:31"
           },
           {
             "label": "_programCreditLines",
@@ -1278,7 +1278,7 @@
             "slot": "6",
             "type": "t_mapping(t_uint32,t_address)",
             "contract": "LendingMarketStorage",
-            "src": "src\\LendingMarketStorage.sol:34"
+            "src": "contracts\\LendingMarketStorage.sol:34"
           },
           {
             "label": "_programLiquidityPools",
@@ -1286,7 +1286,7 @@
             "slot": "7",
             "type": "t_mapping(t_uint32,t_address)",
             "contract": "LendingMarketStorage",
-            "src": "src\\LendingMarketStorage.sol:37"
+            "src": "contracts\\LendingMarketStorage.sol:37"
           },
           {
             "label": "_hasAlias",
@@ -1294,7 +1294,7 @@
             "slot": "8",
             "type": "t_mapping(t_address,t_mapping(t_address,t_bool))",
             "contract": "LendingMarketStorage",
-            "src": "src\\LendingMarketStorage.sol:40"
+            "src": "contracts\\LendingMarketStorage.sol:40"
           },
           {
             "label": "__gap",
@@ -1302,7 +1302,7 @@
             "slot": "9",
             "type": "t_array(t_uint256)41_storage",
             "contract": "LendingMarketStorage",
-            "src": "src\\LendingMarketStorage.sol:44"
+            "src": "contracts\\LendingMarketStorage.sol:44"
           }
         ],
         "types": {
@@ -1322,7 +1322,7 @@
             "label": "mapping(address => bool)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_bytes32,t_struct(RoleData)25_storage)": {
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
             "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
             "numberOfBytes": "32"
           },
@@ -1331,14 +1331,14 @@
             "members": [
               {
                 "label": "_roles",
-                "type": "t_mapping(t_bytes32,t_struct(RoleData)25_storage)",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
                 "offset": 0,
                 "slot": "0"
               }
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(InitializableStorage)93_storage": {
+          "t_struct(InitializableStorage)145_storage": {
             "label": "struct Initializable.InitializableStorage",
             "members": [
               {
@@ -1356,7 +1356,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(PausableStorage)219_storage": {
+          "t_struct(PausableStorage)291_storage": {
             "label": "struct PausableUpgradeable.PausableStorage",
             "members": [
               {
@@ -1368,7 +1368,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(RoleData)25_storage": {
+          "t_struct(RoleData)24_storage": {
             "label": "struct AccessControlUpgradeable.RoleData",
             "members": [
               {
@@ -1402,7 +1402,7 @@
             "label": "mapping(address => mapping(address => bool))",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_uint256,t_struct(State)6652_storage)": {
+          "t_mapping(t_uint256,t_struct(State)6678_storage)": {
             "label": "mapping(uint256 => struct Loan.State)",
             "numberOfBytes": "32"
           },
@@ -1410,7 +1410,7 @@
             "label": "mapping(uint32 => address)",
             "numberOfBytes": "32"
           },
-          "t_struct(State)6652_storage": {
+          "t_struct(State)6678_storage": {
             "label": "struct Loan.State",
             "members": [
               {
@@ -1518,7 +1518,433 @@
             {
               "contract": "AccessControlUpgradeable",
               "label": "_roles",
-              "type": "t_mapping(t_bytes32,t_struct(RoleData)25_storage)",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "097b91c509a5e878f9d7785b4dc1c09066b8c698e99650efc9207d201c39b439": {
+      "address": "0x144Dd1083DEE4Da627a7D3576b0a550a5612D4E2",
+      "txHash": "0x0d39614ae8e79588abb2bd78c00b5950383630ee756e1bc9278c7646bb56a2ca",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "_token",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_address",
+            "contract": "CreditLineConfigurable",
+            "src": "contracts\\credit-lines\\CreditLineConfigurable.sol:38"
+          },
+          {
+            "label": "_market",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "CreditLineConfigurable",
+            "src": "contracts\\credit-lines\\CreditLineConfigurable.sol:41"
+          },
+          {
+            "label": "_config",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_struct(CreditLineConfig)5193_storage",
+            "contract": "CreditLineConfigurable",
+            "src": "contracts\\credit-lines\\CreditLineConfigurable.sol:44"
+          },
+          {
+            "label": "_borrowerConfigs",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_struct(BorrowerConfig)5216_storage)",
+            "contract": "CreditLineConfigurable",
+            "src": "contracts\\credit-lines\\CreditLineConfigurable.sol:47"
+          },
+          {
+            "label": "_borrowerStates",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_address,t_struct(BorrowerState)5226_storage)",
+            "contract": "CreditLineConfigurable",
+            "src": "contracts\\credit-lines\\CreditLineConfigurable.sol:50"
+          },
+          {
+            "label": "_migrationState",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_struct(MigrationState)5234_storage",
+            "contract": "CreditLineConfigurable",
+            "src": "contracts\\credit-lines\\CreditLineConfigurable.sol:52"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_array(t_uint256)44_storage",
+            "contract": "CreditLineConfigurable",
+            "src": "contracts\\credit-lines\\CreditLineConfigurable.sol:56"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)145_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)291_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_uint256)44_storage": {
+            "label": "uint256[44]",
+            "numberOfBytes": "1408"
+          },
+          "t_enum(BorrowPolicy)5167": {
+            "label": "enum ICreditLineConfigurable.BorrowPolicy",
+            "members": [
+              "SingleActiveLoan",
+              "MultipleActiveLoans",
+              "TotalActiveAmountLimit"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_struct(BorrowerConfig)5216_storage)": {
+            "label": "mapping(address => struct ICreditLineConfigurable.BorrowerConfig)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(BorrowerState)5226_storage)": {
+            "label": "mapping(address => struct ICreditLineConfigurable.BorrowerState)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BorrowerConfig)5216_storage": {
+            "label": "struct ICreditLineConfigurable.BorrowerConfig",
+            "members": [
+              {
+                "label": "expiration",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "minDurationInPeriods",
+                "type": "t_uint32",
+                "offset": 4,
+                "slot": "0"
+              },
+              {
+                "label": "maxDurationInPeriods",
+                "type": "t_uint32",
+                "offset": 8,
+                "slot": "0"
+              },
+              {
+                "label": "minBorrowAmount",
+                "type": "t_uint64",
+                "offset": 12,
+                "slot": "0"
+              },
+              {
+                "label": "maxBorrowAmount",
+                "type": "t_uint64",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "borrowPolicy",
+                "type": "t_enum(BorrowPolicy)5167",
+                "offset": 28,
+                "slot": "0"
+              },
+              {
+                "label": "interestRatePrimary",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "interestRateSecondary",
+                "type": "t_uint32",
+                "offset": 4,
+                "slot": "1"
+              },
+              {
+                "label": "addonFixedRate",
+                "type": "t_uint32",
+                "offset": 8,
+                "slot": "1"
+              },
+              {
+                "label": "addonPeriodRate",
+                "type": "t_uint32",
+                "offset": 12,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(BorrowerState)5226_storage": {
+            "label": "struct ICreditLineConfigurable.BorrowerState",
+            "members": [
+              {
+                "label": "activeLoanCount",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "closedLoanCount",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              },
+              {
+                "label": "totalActiveLoanAmount",
+                "type": "t_uint64",
+                "offset": 4,
+                "slot": "0"
+              },
+              {
+                "label": "totalClosedLoanAmount",
+                "type": "t_uint64",
+                "offset": 12,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(CreditLineConfig)5193_storage": {
+            "label": "struct ICreditLineConfigurable.CreditLineConfig",
+            "members": [
+              {
+                "label": "minBorrowAmount",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "maxBorrowAmount",
+                "type": "t_uint64",
+                "offset": 8,
+                "slot": "0"
+              },
+              {
+                "label": "minInterestRatePrimary",
+                "type": "t_uint32",
+                "offset": 16,
+                "slot": "0"
+              },
+              {
+                "label": "maxInterestRatePrimary",
+                "type": "t_uint32",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "minInterestRateSecondary",
+                "type": "t_uint32",
+                "offset": 24,
+                "slot": "0"
+              },
+              {
+                "label": "maxInterestRateSecondary",
+                "type": "t_uint32",
+                "offset": 28,
+                "slot": "0"
+              },
+              {
+                "label": "minDurationInPeriods",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "maxDurationInPeriods",
+                "type": "t_uint32",
+                "offset": 4,
+                "slot": "1"
+              },
+              {
+                "label": "minAddonFixedRate",
+                "type": "t_uint32",
+                "offset": 8,
+                "slot": "1"
+              },
+              {
+                "label": "maxAddonFixedRate",
+                "type": "t_uint32",
+                "offset": 12,
+                "slot": "1"
+              },
+              {
+                "label": "minAddonPeriodRate",
+                "type": "t_uint32",
+                "offset": 16,
+                "slot": "1"
+              },
+              {
+                "label": "maxAddonPeriodRate",
+                "type": "t_uint32",
+                "offset": 20,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(MigrationState)5234_storage": {
+            "label": "struct ICreditLineConfigurable.MigrationState",
+            "members": [
+              {
+                "label": "nextLoanId",
+                "type": "t_uint128",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "done",
+                "type": "t_bool",
+                "offset": 16,
+                "slot": "0"
+              },
+              {
+                "label": "borrowerConfigurationPaused",
+                "type": "t_bool",
+                "offset": 17,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint128": {
+            "label": "uint128",
+            "numberOfBytes": "16"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
               "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61",
               "offset": 0,
               "slot": "0"

--- a/.openzeppelin/unknown-2009.json
+++ b/.openzeppelin/unknown-2009.json
@@ -1544,6 +1544,432 @@
           ]
         }
       }
+    },
+    "097b91c509a5e878f9d7785b4dc1c09066b8c698e99650efc9207d201c39b439": {
+      "address": "0x54a85646acAA065e724cCD623770f49c974fEbC6",
+      "txHash": "0x6b23e0607d028aa80caef2ab86e2b79af9fdc198a88b8198ff00ceba0bcac380",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "_token",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_address",
+            "contract": "CreditLineConfigurable",
+            "src": "contracts\\credit-lines\\CreditLineConfigurable.sol:38"
+          },
+          {
+            "label": "_market",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_address",
+            "contract": "CreditLineConfigurable",
+            "src": "contracts\\credit-lines\\CreditLineConfigurable.sol:41"
+          },
+          {
+            "label": "_config",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_struct(CreditLineConfig)5193_storage",
+            "contract": "CreditLineConfigurable",
+            "src": "contracts\\credit-lines\\CreditLineConfigurable.sol:44"
+          },
+          {
+            "label": "_borrowerConfigs",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_struct(BorrowerConfig)5216_storage)",
+            "contract": "CreditLineConfigurable",
+            "src": "contracts\\credit-lines\\CreditLineConfigurable.sol:47"
+          },
+          {
+            "label": "_borrowerStates",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_address,t_struct(BorrowerState)5226_storage)",
+            "contract": "CreditLineConfigurable",
+            "src": "contracts\\credit-lines\\CreditLineConfigurable.sol:50"
+          },
+          {
+            "label": "_migrationState",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_struct(MigrationState)5234_storage",
+            "contract": "CreditLineConfigurable",
+            "src": "contracts\\credit-lines\\CreditLineConfigurable.sol:52"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_array(t_uint256)44_storage",
+            "contract": "CreditLineConfigurable",
+            "src": "contracts\\credit-lines\\CreditLineConfigurable.sol:56"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)24_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)34_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)145_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)291_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)24_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_uint256)44_storage": {
+            "label": "uint256[44]",
+            "numberOfBytes": "1408"
+          },
+          "t_enum(BorrowPolicy)5167": {
+            "label": "enum ICreditLineConfigurable.BorrowPolicy",
+            "members": [
+              "SingleActiveLoan",
+              "MultipleActiveLoans",
+              "TotalActiveAmountLimit"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_struct(BorrowerConfig)5216_storage)": {
+            "label": "mapping(address => struct ICreditLineConfigurable.BorrowerConfig)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(BorrowerState)5226_storage)": {
+            "label": "mapping(address => struct ICreditLineConfigurable.BorrowerState)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BorrowerConfig)5216_storage": {
+            "label": "struct ICreditLineConfigurable.BorrowerConfig",
+            "members": [
+              {
+                "label": "expiration",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "minDurationInPeriods",
+                "type": "t_uint32",
+                "offset": 4,
+                "slot": "0"
+              },
+              {
+                "label": "maxDurationInPeriods",
+                "type": "t_uint32",
+                "offset": 8,
+                "slot": "0"
+              },
+              {
+                "label": "minBorrowAmount",
+                "type": "t_uint64",
+                "offset": 12,
+                "slot": "0"
+              },
+              {
+                "label": "maxBorrowAmount",
+                "type": "t_uint64",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "borrowPolicy",
+                "type": "t_enum(BorrowPolicy)5167",
+                "offset": 28,
+                "slot": "0"
+              },
+              {
+                "label": "interestRatePrimary",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "interestRateSecondary",
+                "type": "t_uint32",
+                "offset": 4,
+                "slot": "1"
+              },
+              {
+                "label": "addonFixedRate",
+                "type": "t_uint32",
+                "offset": 8,
+                "slot": "1"
+              },
+              {
+                "label": "addonPeriodRate",
+                "type": "t_uint32",
+                "offset": 12,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(BorrowerState)5226_storage": {
+            "label": "struct ICreditLineConfigurable.BorrowerState",
+            "members": [
+              {
+                "label": "activeLoanCount",
+                "type": "t_uint16",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "closedLoanCount",
+                "type": "t_uint16",
+                "offset": 2,
+                "slot": "0"
+              },
+              {
+                "label": "totalActiveLoanAmount",
+                "type": "t_uint64",
+                "offset": 4,
+                "slot": "0"
+              },
+              {
+                "label": "totalClosedLoanAmount",
+                "type": "t_uint64",
+                "offset": 12,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(CreditLineConfig)5193_storage": {
+            "label": "struct ICreditLineConfigurable.CreditLineConfig",
+            "members": [
+              {
+                "label": "minBorrowAmount",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "maxBorrowAmount",
+                "type": "t_uint64",
+                "offset": 8,
+                "slot": "0"
+              },
+              {
+                "label": "minInterestRatePrimary",
+                "type": "t_uint32",
+                "offset": 16,
+                "slot": "0"
+              },
+              {
+                "label": "maxInterestRatePrimary",
+                "type": "t_uint32",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "minInterestRateSecondary",
+                "type": "t_uint32",
+                "offset": 24,
+                "slot": "0"
+              },
+              {
+                "label": "maxInterestRateSecondary",
+                "type": "t_uint32",
+                "offset": 28,
+                "slot": "0"
+              },
+              {
+                "label": "minDurationInPeriods",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "maxDurationInPeriods",
+                "type": "t_uint32",
+                "offset": 4,
+                "slot": "1"
+              },
+              {
+                "label": "minAddonFixedRate",
+                "type": "t_uint32",
+                "offset": 8,
+                "slot": "1"
+              },
+              {
+                "label": "maxAddonFixedRate",
+                "type": "t_uint32",
+                "offset": 12,
+                "slot": "1"
+              },
+              {
+                "label": "minAddonPeriodRate",
+                "type": "t_uint32",
+                "offset": 16,
+                "slot": "1"
+              },
+              {
+                "label": "maxAddonPeriodRate",
+                "type": "t_uint32",
+                "offset": 20,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(MigrationState)5234_storage": {
+            "label": "struct ICreditLineConfigurable.MigrationState",
+            "members": [
+              {
+                "label": "nextLoanId",
+                "type": "t_uint128",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "done",
+                "type": "t_bool",
+                "offset": 16,
+                "slot": "0"
+              },
+              {
+                "label": "borrowerConfigurationPaused",
+                "type": "t_bool",
+                "offset": 17,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint128": {
+            "label": "uint128",
+            "numberOfBytes": "16"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)24_storage)",
+              "src": "@openzeppelin\\contracts-upgradeable\\access\\AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -153,13 +153,14 @@ contract LendingMarket is
         uint256 borrowAmount,
         uint256 durationInPeriods
     ) external whenNotPaused returns (uint256) {
-        return _takeLoan(
-            _msgSender(), // borrower
-            programId,
-            borrowAmount,
-            -1,           // addonAmount -- calculate internally
-            durationInPeriods
-        );
+        return
+            _takeLoan(
+                _msgSender(), // borrower
+                programId,
+                borrowAmount,
+                -1, // addonAmount -- calculate internally
+                durationInPeriods
+            );
     }
 
     /// @inheritdoc ILendingMarket
@@ -176,13 +177,14 @@ contract LendingMarket is
         if (borrower == address(0)) {
             revert Error.ZeroAddress();
         }
-        return _takeLoan(
-            borrower,
-            programId,
-            borrowAmount,
-            int256(addonAmount),
-            durationInPeriods
-        );
+        return
+            _takeLoan(
+                borrower, // Tools: this comment prevents Prettier from formatting into a single line.
+                programId,
+                borrowAmount,
+                int256(addonAmount),
+                durationInPeriods
+            );
     }
 
     /// @dev Takes a loan for a provided account internally.
@@ -222,7 +224,7 @@ contract LendingMarket is
 
         uint256 id = _loanIdCounter++;
         Loan.Terms memory terms = ICreditLine(creditLine).determineLoanTerms(
-            borrower,
+            borrower, // Tools: this comment prevents Prettier from formatting into a single line.
             borrowAmount,
             durationInPeriods
         );
@@ -367,7 +369,7 @@ contract LendingMarket is
 
     /// @inheritdoc ILendingMarket
     function createProgram(
-        address creditLine,
+        address creditLine, // Tools: this comment prevents Prettier from formatting into a single line.
         address liquidityPool
     ) external whenNotPaused {
         if (creditLine == address(0)) {
@@ -397,7 +399,7 @@ contract LendingMarket is
 
     /// @inheritdoc ILendingMarket
     function updateProgram(
-        uint32 programId,
+        uint32 programId, // Tools: this comment prevents Prettier from formatting into a single line.
         address creditLine,
         address liquidityPool
     ) external whenNotPaused {
@@ -664,7 +666,7 @@ contract LendingMarket is
                 originalBalance,
                 numberOfPeriods,
                 interestRate,
-            interestRateFactor_
+                interestRateFactor_
             );
     }
 

--- a/contracts/LendingMarketUUPS.sol
+++ b/contracts/LendingMarketUUPS.sol
@@ -16,5 +16,5 @@ contract LendingMarketUUPS is LendingMarket, UUPSUpgradeable {
     }
 
     /// @inheritdoc UUPSUpgradeable
-    function _authorizeUpgrade(address newImplementation) internal override onlyRole(OWNER_ROLE) { }
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(OWNER_ROLE) {}
 }

--- a/contracts/common/interfaces/ICreditLineConfigurable.sol
+++ b/contracts/common/interfaces/ICreditLineConfigurable.sol
@@ -16,16 +16,16 @@ interface ICreditLineConfigurable is ICreditLine {
     ///
     /// Possible values:
     ///
-    /// - SingleActiveLoan = 0 ----- Only one active loan is allowed; additional loan requests will be rejected.
-    /// - MultipleActiveLoans = 1 -- Multiple active loans are allowed without a total amount limit.
-    /// - TotalAmountLimit = 2 ----- Multiple active loans are allowed, but their total amount
-    ///                              must not exceed the maximum amount of a single loan.
+    /// - SingleActiveLoan = 0 -------- Only one active loan is allowed; additional loan requests will be rejected.
+    /// - MultipleActiveLoans = 1 ----- Multiple active loans are allowed without a total amount limit.
+    /// - TotalActiveAmountLimit = 2 -- Multiple active loans are allowed, but their total amount
+    ///                                 must not exceed the maximum amount of a single loan. TODO rewrite
     ///
     /// Note: In all cases, each individual loan must comply with the minimum and maximum amount limits.
     enum BorrowPolicy {
         SingleActiveLoan,
         MultipleActiveLoans,
-        TotalAmountLimit
+        TotalActiveAmountLimit
     }
 
     /// @dev A struct that defines credit line configuration.
@@ -71,8 +71,6 @@ interface ICreditLineConfigurable is ICreditLine {
     /// closedLoanCount -- the number of loans that have been closed, with or without a full repayment.
     /// totalActiveLoanAmount -- the total amount borrowed across all active loans.
     /// totalClosedLoanAmount -- the total amount that was borrowed across all closed loans.
-    /// TODO: Implement a view function for this structure
-    /// TODO: Implement a service function to fill this structure for existing borrowers
     struct BorrowerState {
         // Slot 1
         uint16 activeLoanCount;
@@ -85,8 +83,8 @@ interface ICreditLineConfigurable is ICreditLine {
     /// @dev TODO:
     struct MigrationState {
         // Slot 1
-        bool done;
         uint128 nextLoanId;
+        bool done;
     }
 
     // -------------------------------------------- //
@@ -124,6 +122,11 @@ interface ICreditLineConfigurable is ICreditLine {
     /// @param borrower The address of the borrower to check.
     /// @return The structure containing the borrower configuration.
     function getBorrowerConfiguration(address borrower) external view returns (BorrowerConfig memory);
+
+    /// @dev Retrieves the state of a borrower.
+    /// @param borrower The address of the borrower to check.
+    /// @return The structure containing the borrower state.
+    function getBorrowerState(address borrower) external view returns (BorrowerState memory);
 
     /// @dev Retrieves the credit line configuration.
     /// @return The structure containing the credit line configuration.

--- a/contracts/common/interfaces/ICreditLineConfigurable.sol
+++ b/contracts/common/interfaces/ICreditLineConfigurable.sol
@@ -12,18 +12,20 @@ interface ICreditLineConfigurable is ICreditLine {
     //  Structs and enums                           //
     // -------------------------------------------- //
 
-    /// @dev An enum that defines the available borrow policies.
+    /// @dev Defines the available borrow policies.
     ///
-    /// The possible values:
+    /// Possible values:
     ///
-    /// - Reset ---- Reset the borrow allowance after the first loan taken.
-    /// - Keep ----- Do not change anything about the borrow allowance.
-    /// - Decrease - Decrease the borrow allowance after each loan taken.
+    /// - SingleActiveLoan = 0 ----- Only one active loan is allowed; additional loan requests will be rejected.
+    /// - MultipleActiveLoans = 1 -- Multiple active loans are allowed without a total amount limit.
+    /// - TotalAmountLimit = 2 ----- Multiple active loans are allowed, but their total amount
+    ///                              must not exceed the maximum amount of a single loan.
+    ///
+    /// Note: In all cases, each individual loan must comply with the minimum and maximum amount limits.
     enum BorrowPolicy {
-        Reset,           // 0
-        Keep,            // 1
-        Iterate,         // 2
-        Decrease         // 3
+        SingleActiveLoan,
+        MultipleActiveLoans,
+        TotalAmountLimit
     }
 
     /// @dev A struct that defines credit line configuration.
@@ -59,6 +61,32 @@ interface ICreditLineConfigurable is ICreditLine {
         uint32 interestRateSecondary;     // The secondary interest rate to be applied to the loan.
         uint32 addonFixedRate;            // The fixed rate for the loan addon calculation (extra charges or fees).
         uint32 addonPeriodRate;           // The period rate for the loan addon calculation (extra charges or fees).
+    }
+
+    /// @dev Defines a borrower state.
+    ///
+    /// Fields:
+    ///
+    /// activeLoanCount -- the number of active loans currently held by the borrower.
+    /// closedLoanCount -- the number of loans that have been closed, with or without a full repayment.
+    /// totalActiveLoanAmount -- the total amount borrowed across all active loans.
+    /// totalClosedLoanAmount -- the total amount that was borrowed across all closed loans.
+    /// TODO: Implement a view function for this structure
+    /// TODO: Implement a service function to fill this structure for existing borrowers
+    struct BorrowerState {
+        // Slot 1
+        uint16 activeLoanCount;
+        uint16 closedLoanCount;
+        uint64 totalActiveLoanAmount;
+        uint64 totalClosedLoanAmount;
+        // uint96 __reserved; // Reserved for future use until the end of the storage slot.
+    }
+
+    /// @dev TODO:
+    struct MigrationState {
+        // Slot 1
+        bool done;
+        uint128 nextLoanId;
     }
 
     // -------------------------------------------- //

--- a/contracts/common/interfaces/ICreditLineConfigurable.sol
+++ b/contracts/common/interfaces/ICreditLineConfigurable.sol
@@ -17,9 +17,9 @@ interface ICreditLineConfigurable is ICreditLine {
     /// Possible values:
     ///
     /// - SingleActiveLoan = 0 -------- Only one active loan is allowed; additional loan requests will be rejected.
-    /// - MultipleActiveLoans = 1 ----- Multiple active loans are allowed without a total amount limit.
-    /// - TotalActiveAmountLimit = 2 -- Multiple active loans are allowed, but their total amount
-    ///                                 must not exceed the maximum amount of a single loan. TODO rewrite
+    /// - MultipleActiveLoans = 1 ------ Multiple active loans are allowed, with no limit on the total borrowed amount.
+    /// - TotalActiveAmountLimit = 2 --- Multiple active loans are allowed, but their total borrowed amount cannot
+    ///                                  exceed the maximum borrow amount of a single loan specified for the borrower.
     ///
     /// Note: In all cases, each individual loan must comply with the minimum and maximum amount limits.
     enum BorrowPolicy {
@@ -80,7 +80,7 @@ interface ICreditLineConfigurable is ICreditLine {
         // uint96 __reserved; // Reserved for future use until the end of the storage slot.
     }
 
-    /// @dev TODO:
+    /// @dev Defines the migration state.
     struct MigrationState {
         // Slot 1
         uint128 nextLoanId;

--- a/contracts/common/interfaces/ICreditLineConfigurable.sol
+++ b/contracts/common/interfaces/ICreditLineConfigurable.sol
@@ -85,6 +85,7 @@ interface ICreditLineConfigurable is ICreditLine {
         // Slot 1
         uint128 nextLoanId;
         bool done;
+        bool borrowerConfigurationPaused;
     }
 
     // -------------------------------------------- //

--- a/contracts/common/interfaces/core/ILendingMarket.sol
+++ b/contracts/common/interfaces/core/ILendingMarket.sol
@@ -12,14 +12,13 @@ interface ILendingMarket {
     //  Events                                      //
     // -------------------------------------------- //
 
-
     /// @dev Emitted when a loan is taken.
     /// @param loanId The unique identifier of the loan.
     /// @param borrower The address of the borrower of the loan.
     /// @param borrowAmount The initial total amount of the loan, including the addon.
     /// @param durationInPeriods The duration of the loan in periods.
     event LoanTaken(
-        uint256 indexed loanId,
+        uint256 indexed loanId, // Tools: this comment prevents Prettier from formatting into a single line.
         address indexed borrower,
         uint256 borrowAmount,
         uint256 durationInPeriods
@@ -56,7 +55,7 @@ interface ILendingMarket {
     /// @param newDuration The new duration of the loan in periods.
     /// @param oldDuration The old duration of the loan in periods.
     event LoanDurationUpdated(
-        uint256 indexed loanId,
+        uint256 indexed loanId, // Tools: this comment prevents Prettier from formatting into a single line.
         uint256 indexed newDuration,
         uint256 indexed oldDuration
     );
@@ -81,12 +80,11 @@ interface ILendingMarket {
         uint256 indexed oldInterestRate
     );
 
-
     /// @dev Emitted when a new credit line is registered.
     /// @param lender The address of the lender who registered the credit line.
     /// @param creditLine The address of the credit line registered.
     event CreditLineRegistered(
-        address indexed lender,
+        address indexed lender, // Tools: this comment prevents Prettier from formatting into a single line.
         address indexed creditLine
     );
 
@@ -94,7 +92,7 @@ interface ILendingMarket {
     /// @param lender The address of the lender who registered the liquidity pool.
     /// @param liquidityPool The address of the liquidity pool registered.
     event LiquidityPoolRegistered(
-        address indexed lender,
+        address indexed lender, // Tools: this comment prevents Prettier from formatting into a single line.
         address indexed liquidityPool
     );
 
@@ -102,7 +100,7 @@ interface ILendingMarket {
     /// @param lender The address of the lender who created the program.
     /// @param programId The unique identifier of the program.
     event ProgramCreated(
-        address indexed lender,
+        address indexed lender, // Tools: this comment prevents Prettier from formatting into a single line.
         uint32 indexed programId
     );
 
@@ -111,7 +109,7 @@ interface ILendingMarket {
     /// @param creditLine The address of the credit line associated with the program.
     /// @param liquidityPool The address of the liquidity pool associated with the program.
     event ProgramUpdated(
-        uint32 indexed programId,
+        uint32 indexed programId, // Tools: this comment prevents Prettier from formatting into a single line.
         address indexed creditLine,
         address indexed liquidityPool
     );
@@ -121,7 +119,7 @@ interface ILendingMarket {
     /// @param account The address of the alias account.
     /// @param isAlias True if the account is configured as an alias, otherwise false.
     event LenderAliasConfigured(
-        address indexed lender,
+        address indexed lender, // Tools: this comment prevents Prettier from formatting into a single line.
         address indexed account,
         bool isAlias
     );
@@ -136,7 +134,7 @@ interface ILendingMarket {
     /// @param durationInPeriods The desired duration of the loan in periods.
     /// @return The unique identifier of the loan.
     function takeLoan(
-        uint32 programId,
+        uint32 programId, // Tools: this comment prevents Prettier from formatting into a single line.
         uint256 borrowAmount,
         uint256 durationInPeriods
     ) external returns (uint256);

--- a/contracts/common/libraries/Round.sol
+++ b/contracts/common/libraries/Round.sol
@@ -12,11 +12,4 @@ library Round {
     function roundUp(uint256 value, uint256 accuracy) internal pure returns (uint256) {
         return ((value + accuracy - 1) / accuracy) * accuracy;
     }
-
-    /// @dev Rounds down a value to the nearest multiple of an accuracy.
-    /// @param value The value to be rounded.
-    /// @param accuracy The accuracy to which the value should be rounded.
-    function roundDown(uint256 value, uint256 accuracy) internal pure returns (uint256) {
-        return (value / accuracy) * accuracy;
-    }
 }

--- a/contracts/common/libraries/Round.sol
+++ b/contracts/common/libraries/Round.sol
@@ -10,13 +10,13 @@ library Round {
     /// @param value The value to be rounded.
     /// @param accuracy The accuracy to which the value should be rounded.
     function roundUp(uint256 value, uint256 accuracy) internal pure returns (uint256) {
-        return (value + accuracy - 1) / accuracy * accuracy;
+        return ((value + accuracy - 1) / accuracy) * accuracy;
     }
 
     /// @dev Rounds down a value to the nearest multiple of an accuracy.
     /// @param value The value to be rounded.
     /// @param accuracy The accuracy to which the value should be rounded.
     function roundDown(uint256 value, uint256 accuracy) internal pure returns (uint256) {
-        return value / accuracy * accuracy;
+        return (value / accuracy) * accuracy;
     }
 }

--- a/contracts/credit-lines/CreditLineConfigurable.sol
+++ b/contracts/credit-lines/CreditLineConfigurable.sol
@@ -74,10 +74,10 @@ contract CreditLineConfigurable is AccessControlExtUpgradeable, PausableUpgradea
     /// @dev Thrown when another loan is requested by an account but only one active loan is allowed.
     error LimitViolationOnSingleActiveLoan();
 
-    /// @dev Thrown when // TODO
+    /// @dev Thrown when the total borrowed amount of active loans exceeds the maximum borrow amount of a single loan.
     error LimitViolationOnTotalActiveLoanAmount(uint256 newTotalActiveLoanAmount);
 
-    /// @dev Thrown when // TODO
+    /// @dev Thrown when the borrower state counters or amounts would overflow their maximum values.
     error BorrowerStateOverflow();
 
     // -------------------------------------------- //
@@ -429,7 +429,8 @@ contract CreditLineConfigurable is AccessControlExtUpgradeable, PausableUpgradea
         return block.timestamp - Constants.NEGATIVE_TIME_OFFSET;
     }
 
-    /// @dev TODO
+    /// @dev Executes additional checks and updates the borrower structures when a loan is opened.
+    /// @param loan The state of the loan that is being opened.
     function _openLoan(Loan.State memory loan) internal {
         BorrowerConfig storage borrowerConfig = _borrowerConfigs[loan.borrower];
 
@@ -470,7 +471,8 @@ contract CreditLineConfigurable is AccessControlExtUpgradeable, PausableUpgradea
         }
     }
 
-    /// @dev TODO
+    /// @dev Updates the borrower structures when a loan is closed.
+    /// @param loan The state of the loan thai is being closed.
     function _closeLoan(Loan.State memory loan) internal {
         if (_migrationState.done) {
             BorrowerState storage borrowerState = _borrowerStates[loan.borrower];
@@ -490,7 +492,8 @@ contract CreditLineConfigurable is AccessControlExtUpgradeable, PausableUpgradea
     //  Migration service functions                 //
     // -------------------------------------------- //
 
-    /// @dev TODO
+    /// @dev Migrates the borrower state from the old logic to the new one.
+    /// @param loanIdCount The number of loan IDs to migrate.
     function migrateBorrowerState(uint256 loanIdCount) public {
         uint256 loanId = _migrationState.nextLoanId;
         if (loanIdCount > type(uint256).max - loanId) {
@@ -514,7 +517,7 @@ contract CreditLineConfigurable is AccessControlExtUpgradeable, PausableUpgradea
         _migrationState.nextLoanId = uint128(endLoanId);
     }
 
-    /// @dev TODO
+    /// @dev Migrates the loan limitation logic from the old logic to the new one.
     function migrateLoanLimitationLogic() external onlyRole(OWNER_ROLE) {
         if (!_migrationState.done) {
             migrateBorrowerState(type(uint256).max);
@@ -522,7 +525,7 @@ contract CreditLineConfigurable is AccessControlExtUpgradeable, PausableUpgradea
         }
     }
 
-    /// @dev TODO
+    /// @dev Clears the migration state. Must be called before the next contract upgrading after the migration.
     function clearMigrationState() external onlyRole(OWNER_ROLE) {
         if (_migrationState.done && _migrationState.nextLoanId != 0) {
             _migrationState.done = false;
@@ -530,7 +533,7 @@ contract CreditLineConfigurable is AccessControlExtUpgradeable, PausableUpgradea
         }
     }
 
-    /// @dev TODO
+    /// @dev Returns the migration state structure.
     function migrationState() external view returns (MigrationState memory) {
         return _migrationState;
     }

--- a/contracts/credit-lines/CreditLineConfigurable.sol
+++ b/contracts/credit-lines/CreditLineConfigurable.sol
@@ -88,7 +88,7 @@ contract CreditLineConfigurable is AccessControlExtUpgradeable, PausableUpgradea
     /// @param token_ The address of the token.
     /// See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
     function initialize(
-        address lender_,
+        address lender_, // Tools: this comment prevents Prettier from formatting into a single line.
         address market_,
         address token_
     ) external initializer {
@@ -101,7 +101,7 @@ contract CreditLineConfigurable is AccessControlExtUpgradeable, PausableUpgradea
     /// @param token_ The address of the token.
     /// See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
     function __CreditLineConfigurable_init(
-        address lender_,
+        address lender_, // Tools: this comment prevents Prettier from formatting into a single line.
         address market_,
         address token_
     ) internal onlyInitializing {
@@ -222,9 +222,12 @@ contract CreditLineConfigurable is AccessControlExtUpgradeable, PausableUpgradea
 
         if (borrowerConfig.borrowPolicy == BorrowPolicy.Keep) {
             // Do nothing to the borrower's max borrow amount configuration
-        } else if (borrowerConfig.borrowPolicy == BorrowPolicy.Decrease || borrowerConfig.borrowPolicy == BorrowPolicy.Iterate) {
+        } else if (
+            borrowerConfig.borrowPolicy == BorrowPolicy.Decrease || borrowerConfig.borrowPolicy == BorrowPolicy.Iterate
+        ) {
             borrowerConfig.maxBorrowAmount -= loan.borrowAmount;
-        } else { // borrowerConfig.borrowPolicy == BorrowPolicy.Reset
+        } else {
+            // borrowerConfig.borrowPolicy == BorrowPolicy.Reset
             borrowerConfig.maxBorrowAmount = 0;
         }
 
@@ -294,13 +297,14 @@ contract CreditLineConfigurable is AccessControlExtUpgradeable, PausableUpgradea
         terms.durationInPeriods = durationInPeriods.toUint32();
         terms.interestRatePrimary = borrowerConfig.interestRatePrimary;
         terms.interestRateSecondary = borrowerConfig.interestRateSecondary;
-        terms.addonAmount = Round.roundUp(calculateAddonAmount(
+        uint256 addonAmount = calculateAddonAmount(
             borrowAmount,
             durationInPeriods,
             borrowerConfig.addonFixedRate,
             borrowerConfig.addonPeriodRate,
             Constants.INTEREST_RATE_FACTOR
-        ), Constants.ACCURACY_FACTOR).toUint64();
+        );
+        terms.addonAmount = Round.roundUp(addonAmount, Constants.ACCURACY_FACTOR).toUint64();
     }
 
     /// @inheritdoc ICreditLineConfigurable

--- a/contracts/credit-lines/CreditLineConfigurableUUPS.sol
+++ b/contracts/credit-lines/CreditLineConfigurableUUPS.sol
@@ -16,5 +16,5 @@ contract CreditLineConfigurableUUPS is CreditLineConfigurable, UUPSUpgradeable {
     }
 
     /// @inheritdoc UUPSUpgradeable
-    function _authorizeUpgrade(address newImplementation) internal override onlyRole(OWNER_ROLE) { }
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(OWNER_ROLE) {}
 }

--- a/contracts/liquidity-pools/LiquidityPoolAccountable.sol
+++ b/contracts/liquidity-pools/LiquidityPoolAccountable.sol
@@ -16,7 +16,6 @@ import { ILiquidityPool } from "../common/interfaces/core/ILiquidityPool.sol";
 import { ILiquidityPoolAccountable } from "../common/interfaces/ILiquidityPoolAccountable.sol";
 import { AccessControlExtUpgradeable } from "../common/AccessControlExtUpgradeable.sol";
 
-
 /// @title LiquidityPoolAccountable contract
 /// @author CloudWalk Inc. (See https://cloudwalk.io)
 /// @dev Implementation of the accountable liquidity pool contract.
@@ -82,7 +81,7 @@ contract LiquidityPoolAccountable is AccessControlExtUpgradeable, PausableUpgrad
     /// @param token_ The address of the token.
     /// See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
     function initialize(
-        address lender_,
+        address lender_, // Tools: this comment prevents Prettier from formatting into a single line.
         address market_,
         address token_
     ) external initializer {

--- a/contracts/liquidity-pools/LiquidityPoolAccountableUUPS.sol
+++ b/contracts/liquidity-pools/LiquidityPoolAccountableUUPS.sol
@@ -16,5 +16,5 @@ contract LiquidityPoolAccountableUUPS is LiquidityPoolAccountable, UUPSUpgradeab
     }
 
     /// @inheritdoc UUPSUpgradeable
-    function _authorizeUpgrade(address newImplementation) internal override onlyRole(OWNER_ROLE) { }
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(OWNER_ROLE) {}
 }

--- a/contracts/mocks/ERC20Mock.sol
+++ b/contracts/mocks/ERC20Mock.sol
@@ -9,7 +9,7 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 /// @dev Mock of the `ERC20` token contract used for testing.
 contract ERC20Mock is ERC20 {
     /// @dev Contract constructor.
-    constructor() ERC20("NAME", "SYMBOL") { }
+    constructor() ERC20("NAME", "SYMBOL") {}
 
     /// @dev Mints tokens.
     /// @param to The address to mint tokens to.

--- a/contracts/mocks/LendingMarketMock.sol
+++ b/contracts/mocks/LendingMarketMock.sol
@@ -24,6 +24,7 @@ contract LendingMarketMock is ILendingMarket {
     // -------------------------------------------- //
 
     mapping(uint256 => Loan.State) private _loanStates;
+    uint256 private _loanIdCounter;
 
     // -------------------------------------------- //
     //  ILendingMarket functions                    //
@@ -182,8 +183,8 @@ contract LendingMarketMock is ILendingMarket {
         revert Error.NotImplemented();
     }
 
-    function loanCounter() external pure returns (uint256) {
-        revert Error.NotImplemented();
+    function loanCounter() external view returns (uint256) {
+        return _loanIdCounter;
     }
 
     // -------------------------------------------- //
@@ -192,6 +193,10 @@ contract LendingMarketMock is ILendingMarket {
 
     function mockLoanState(uint256 loanId, Loan.State memory state) external {
         _loanStates[loanId] = state;
+    }
+
+    function setLoanIdCounter(uint256 newLoanIdCounter) external {
+        _loanIdCounter = newLoanIdCounter;
     }
 
     function callOnBeforeLoanTakenLiquidityPool(address liquidityPool, uint256 loanId) external {

--- a/contracts/testables/CreditLineConfigurableTestable.sol
+++ b/contracts/testables/CreditLineConfigurableTestable.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+import { CreditLineConfigurable } from "../credit-lines/CreditLineConfigurable.sol";
+
+/// @title CreditLineConfigurableTestable contract
+/// @author CloudWalk Inc. (See https://cloudwalk.io)
+/// @dev Version of the configurable credit line contract with additions required for testing.
+contract CreditLineConfigurableTestable is CreditLineConfigurable {
+    /// @dev TODO
+    function setBorrowerState(address borrower, BorrowerState calldata newState) external {
+        _borrowerStates[borrower] = newState;
+    }
+
+    /// @dev TODO
+    function setMigrationState(MigrationState calldata newState) external {
+        _migrationState = newState;
+    }
+}

--- a/contracts/testables/CreditLineConfigurableTestable.sol
+++ b/contracts/testables/CreditLineConfigurableTestable.sol
@@ -8,12 +8,15 @@ import { CreditLineConfigurable } from "../credit-lines/CreditLineConfigurable.s
 /// @author CloudWalk Inc. (See https://cloudwalk.io)
 /// @dev Version of the configurable credit line contract with additions required for testing.
 contract CreditLineConfigurableTestable is CreditLineConfigurable {
-    /// @dev TODO
+    /// @dev Sets the borrower state for testing purposes.
+    /// @param borrower The address of the borrower.
+    /// @param newState The new borrower state.
     function setBorrowerState(address borrower, BorrowerState calldata newState) external {
         _borrowerStates[borrower] = newState;
     }
 
-    /// @dev TODO
+    /// @dev Sets the migration state for testing purposes.
+    /// @param newState The new migration state.
     function setMigrationState(MigrationState calldata newState) external {
         _migrationState = newState;
     }

--- a/test/credit-lines/CreditLineConfigurable.test.ts
+++ b/test/credit-lines/CreditLineConfigurable.test.ts
@@ -66,7 +66,7 @@ interface LoanTerms {
 enum BorrowPolicy {
   SingleActiveLoan = 0,
   MultipleActiveLoans = 1,
-  TotalAmountLimit = 2,
+  TotalActiveAmountLimit = 2,
 }
 
 const ERROR_NAME_ALREADY_INITIALIZED = "InvalidInitialization";
@@ -744,7 +744,7 @@ describe("Contract 'CreditLineConfigurable'", async () => {
       expectedBorrowerConfig.borrowPolicy = borrowPolicy;
 
       switch (borrowPolicy) {
-        case BorrowPolicy.TotalAmountLimit:
+        case BorrowPolicy.TotalActiveAmountLimit:
           expectedBorrowerConfig.maxBorrowAmount -= BORROW_AMOUNT;
           break;
         case BorrowPolicy.SingleActiveLoan:
@@ -769,7 +769,7 @@ describe("Contract 'CreditLineConfigurable'", async () => {
     });
 
     it("Executes as expected if the borrow policy is 'TotalAmountLimit'", async () => {
-      await executeAndCheck(BorrowPolicy.TotalAmountLimit);
+      await executeAndCheck(BorrowPolicy.TotalActiveAmountLimit);
     });
 
     it("Is reverted if the caller is not the configured market", async () => {
@@ -809,7 +809,7 @@ describe("Contract 'CreditLineConfigurable'", async () => {
       const loanState: LoanState = await prepareLoan();
 
       const borrowerConfig: BorrowerConfig = createDefaultBorrowerConfiguration();
-      borrowerConfig.borrowPolicy = BorrowPolicy.TotalAmountLimit;
+      borrowerConfig.borrowPolicy = BorrowPolicy.TotalActiveAmountLimit;
       await proveTx(creditLineUnderAdmin.configureBorrower(borrower.address, borrowerConfig));
 
       loanState.trackedBalance = DEFAULT_REPAY_AMOUNT;
@@ -833,7 +833,7 @@ describe("Contract 'CreditLineConfigurable'", async () => {
       const loanState: LoanState = await prepareLoan();
 
       const borrowerConfig: BorrowerConfig = createDefaultBorrowerConfiguration();
-      borrowerConfig.borrowPolicy = BorrowPolicy.TotalAmountLimit;
+      borrowerConfig.borrowPolicy = BorrowPolicy.TotalActiveAmountLimit;
       await proveTx(creditLineUnderAdmin.configureBorrower(borrower.address, borrowerConfig));
 
       loanState.trackedBalance = 0;
@@ -876,7 +876,7 @@ describe("Contract 'CreditLineConfigurable'", async () => {
       const { creditLine, creditLineUnderAdmin } = await setUpFixture(deployAndConfigureCreditLineWithBorrower);
       const loanState: LoanState = await prepareLoan();
       const borrowerConfig: BorrowerConfig = createDefaultBorrowerConfiguration();
-      borrowerConfig.borrowPolicy = BorrowPolicy.TotalAmountLimit;
+      borrowerConfig.borrowPolicy = BorrowPolicy.TotalActiveAmountLimit;
       await proveTx(creditLineUnderAdmin.configureBorrower(borrower.address, borrowerConfig));
 
       // borrow policy == iterate

--- a/test/mocks/LendingMarketMock.test.ts
+++ b/test/mocks/LendingMarketMock.test.ts
@@ -204,12 +204,5 @@ describe("Contract 'LendingMarketMock'", async () => {
       await expect(lendingMarket.timeOffset())
         .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
     });
-
-    it("Function 'loanCounter()'", async () => {
-      const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
-
-      await expect(lendingMarket.loanCounter())
-        .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
-    });
   });
 });


### PR DESCRIPTION
### Main Changes
1. The new `BorrowerState` structure has been introduced in the credit line contract to trace the state of each borrower.
    <details>

    <summary>The new structure definition</summary>

    ```solidity
    /// @dev Defines a borrower state.
    ///
    /// Fields:
    ///
    /// activeLoanCount -- the number of active loans currently held by the borrower.
    /// closedLoanCount -- the number of loans that have been closed, with or without a full repayment.
    /// totalActiveLoanAmount -- the total amount borrowed across all active loans.
    /// totalClosedLoanAmount -- the total amount that was borrowed across all closed loans.
    struct BorrowerState {
        // Slot 1
        uint16 activeLoanCount;
        uint16 closedLoanCount;
        uint64 totalActiveLoanAmount;
        uint64 totalClosedLoanAmount;
        // uint96 __reserved; // Reserved for future use until the end of the storage slot.
    }
    ```

    </details>

2. The new borrowing policies in the form of the `BorrowPolicy` enum have been established to manage the loan limitations for a borrower. The new policies can be configure through the existing functions `configureBorrower()` and `configureBorrowers()` of the credit line contract.

    <details>

    <summary>The new borrowing policies definition</summary>

    ```solidity
    /// @dev Defines the available borrow policies.
    ///
    /// Possible values:
    ///
    /// - SingleActiveLoan = 0 -------- Only one active loan is allowed; additional loan requests will be rejected.
    /// - MultipleActiveLoans = 1 ------ Multiple active loans are allowed, with no limit on the total borrowed amount.
    /// - TotalActiveAmountLimit = 2 --- Multiple active loans are allowed, but their total borrowed amount cannot
    ///                                  exceed the maximum borrow amount of a single loan specified for the borrower.
    ///
    /// Note: In all cases, each individual loan must comply with the minimum and maximum amount limits.
    enum BorrowPolicy {
        SingleActiveLoan,
        MultipleActiveLoans,
        TotalActiveAmountLimit
    }
    ```

    </details>

3. The `BorrowerConfig` structure that stores setting for a borrower has been made immutable by the credit line contract. Previously, with policy 2, the `maxBorrowAmount` field of the structure was reduced by the contract when a loan was taken and increased back when it was closed. This variability in settings led to issues with configuring borrowers. Now a new borrower configuration can be set at any time through the related functions despite the state of the borrower loans.

4. The new loan limitation logic incorporated the new structure and policies has been introduced. It explains in the next section by examples.

5. A migration mechanism from the previous logic to the new one has been introduced. It includes several functions and the `MigrationState` structure. Migration steps are provided in the appropriate section below.

### Policies of Borrowing with Examples

#### Case `BorrowPolicy.TotalActiveAmountLimit`

1. Configure a borrower to borrow up to `1000 BRLC` (decimals = 6), setting `BorrowerConfig.maxBorrowAmount = 1000e6`.
2. The borrower takes a `500 BRLC` loan (`loan.borrowAmount = 500e6`). The `BorrowerState` fields become:
   * `activeLoanCount = 1`;
   * `closedLoanCount = 0`;
   * `totalActiveLoanAmount = 500e6`;
   * `totalClosedLoanAmount = 0`.

4. The borrower takes another `300 BRLC` loan (`loan.borrowAmount = 300e6`). The `BorrowerState` fields become:
   * `activeLoanCount = 2`;
   * `closedLoanCount = 0`;
   * `totalActiveLoanAmount = 800e6`;
   * `totalClosedLoanAmount = 0`.

6. The borrower tries to take another `400 BRLC` loan (`loan.borrowAmount = 400e6`), but it's rejected because: `BorrowerState.totalActiveLoanAmount + loan.borrowAmount > BorrowerConfig.maxBorrowAmount`.

7. Later, the total loan limit is decreased to `500 BRLC`, setting `BorrowerConfig.maxBorrowAmount = 500e6`. The borrower is no longer able to take further loans because `BorrowerState.totalActiveLoanAmount >= BorrowerConfig.maxBorrowAmount`. Similarly, the limit can be increased, or the borrow policy changed.

8. The borrower fully repays the second loan. The `BorrowerState` fields become:
   * `activeLoanCount = 1`;
   * `closedLoanCount = 1`;
   * `totalActiveLoanAmount = 500e6`;
   * `totalClosedLoanAmount = 300e6`.

   However, the borrower still cannot take another loan as `BorrowerState.totalActiveLoanAmount >= BorrowerConfig.maxBorrowAmount` remains true.

9. The borrower fully repays the first loan. The `BorrowerState` fields become:
   * `activeLoanCount = 0`;
   * `closedLoanCount = 2`;
   * `totalActiveLoanAmount = 0`;
   * `totalClosedLoanAmount = 800e6`.

   Now, the borrower can take out a new loan(s) not exceeding `500 BRLC` in total. Each loan must also comply with `loan.borrowAmount <= BorrowerConfig.maxBorrowAmount`.

#### Case `BorrowPolicy.MultipleActiveLoans`

1. Configure a borrower to borrow up to `1000 BRLC` (decimals = 6), setting `BorrowerConfig.maxBorrowAmount = 1000e6`.
2. The borrower takes a `1000 BRLC` loan (`loan.borrowAmount = 1000e6`). The `BorrowerState` fields become:
   * `activeLoanCount = 1`;
   * `closedLoanCount = 0`;
   * `totalActiveLoanAmount = 1000e6`;
   * `totalClosedLoanAmount = 0`.

4. The borrower takes another `500 BRLC` loan (`loan.borrowAmount = 500e6`). The `BorrowerState` fields become:
   * `activeLoanCount = 2`;
   * `closedLoanCount = 0`;
   * `totalActiveLoanAmount = 1500e6`;
   * `totalClosedLoanAmount = 0`.

   The `BorrowerState.totalActiveLoanAmount >= BorrowerConfig.maxBorrowAmount` condition is ignored in this case, as the policy is not `TotalActiveAmountLimit`.

5. The borrower tries to take another `1100 BRLC` loan (`loan.borrowAmount = 1100e6`), but it's rejected because: `loan.borrowAmount > BorrowerConfig.maxBorrowAmount`.

6. The borrower can take as many loans as desired, but each loan's amount must be less than `BorrowerConfig.maxBorrowAmount`.

#### Case `BorrowPolicy.SingleActiveLoan`

1. Configure a borrower to borrow up to `1000 BRLC` (decimals = 6), setting `BorrowerConfig.maxBorrowAmount = 1000e6`.
2. The borrower takes a `500 BRLC` loan (`loan.borrowAmount = 500e6`). The `BorrowerState` fields become:
   * `activeLoanCount = 1`;
   * `closedLoanCount = 0`;
   * `totalActiveLoanAmount = 500e6`;
   * `totalClosedLoanAmount = 0`.

3. The borrower attempts to take another `300 BRLC` loan (`loan.borrowAmount = 300e6`), but it's rejected because: `BorrowerState.activeLoanCount > 0`.

4. The borrower can only take another loan after fully repaying the current one. Also, the condition `loan.borrowAmount <= BorrowerConfig.maxBorrowAmount` must be met for any single loan.

### Migration Steps

1. Upgrade the `CreditLineConfigurableUUPS` contract on the blockchain.
2. Pause the lending market contract.
3. Retrieve the current number of loans `LN` by calling the `LendingMarketUUPS.loanCounter()` function.
4. Execute the `CreditLineConfigurableUUPS.migrateBorrowerState(n)` function as needed until `MigrationState.nextLoanId >= LN - 10`. Choose `n` based on your blockchain's gas limit; a default value could be `n = 500`. Use the `migrationState()` function to read the `MigrationState` structure.
5. Call the `CreditLineConfigurableUUPS.migrateLoanLimitationLogic()` function to finish migrating borrower states. Ensure that `MigrationState.done = true` after the call.
6. Unpause the lending market contract.
7. Call `CreditLineConfigurableUUPS.setBorrowerConfigurationPause(true)` to prevent changes to borrower configurations.
8. Collect the `maxBorrowAmount` values previously set for each borrower during the most recent configurations (before the pause). Use a database query to fetch the needed data.
9. Set the correct `maxBorrowAmount` values for each borrower using the `CreditLineConfigurableUUPS.setMaxBorrowAmount()` function, based on the values collected in the previous step.
10. Call `CreditLineConfigurableUUPS.setBorrowerConfigurationPause(false)` to unpause borrower configuration.
11. Migration is complete. To clear the storage slot occupied by the `MigrationState` structure, call the `clearMigrationState()` function just before the next contract upgrade. Use a batch transaction execution or a pause/unpause flow for the upgrade.

Note: These steps can be completed using a script.

## Test Coverage
The new logic and migration functions are fully covered by tests.

<details>

<summary>Test coverage details</summary>

| File                                    |  % Stmts | % Branch |  % Funcs |  % Lines |
|-----------------------------------------|---------:|---------:|---------:|---------:|
| contracts/                              |    97.24 |    92.17 |   100.00 |    95.81 |
| ├─ LendingMarket.sol                    |    97.22 |    92.07 |   100.00 |    95.79 |
| ├─ LendingMarketStorage.sol             |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketUUPS.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/                       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeable.sol      |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/interfaces/            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICreditLineConfigurable.sol          |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILiquidityPoolAccountable.sol        |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/interfaces/core/       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICreditLine.sol                      |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILendingMarket.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILiquidityPool.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/libraries/             |    68.25 |    39.19 |   100.00 |    61.98 |
| ├─ ABDKMath64x64.sol                    |    62.26 |    33.82 |   100.00 |    57.01 |
| ├─ Constants.sol                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Error.sol                            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ InterestMath.sol                     |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Loan.sol                             |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Round.sol                            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ SafeCast.sol                         |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/credit-lines/                 |   100.00 |    98.03 |   100.00 |   100.00 |
| ├─ CreditLineConfigurable.sol           |   100.00 |    98.00 |   100.00 |   100.00 |
| ├─ CreditLineConfigurableUUPS.sol       |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/liquidity-pools/              |   100.00 |    91.67 |   100.00 |   100.00 |
| ├─ LiquidityPoolAccountable.sol         |   100.00 |    91.38 |   100.00 |   100.00 |
| ├─ LiquidityPoolAccountableUUPS.sol     |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/mocks/                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeableMock.sol  |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineMock.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ERC20Mock.sol                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketMock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPoolMock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/testables/                    |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineConfigurableTestable.sol   |   100.00 |   100.00 |   100.00 |   100.00 |
|-----------------------------------------|----------|----------|----------|----------|
| All files                               |    94.04 |    85.71 |   100.00 |    92.14 |
|-----------------------------------------|----------|----------|----------|----------|

</details>

