### PR TITLE
feat: introduce `UUPSExtUpgradeable` base contract

### DIFF
--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -76,9 +76,6 @@ contract LendingMarket is
     /// @dev Thrown when the program does not exist.
     error ProgramNotExist();
 
-    /// @dev Thrown if the provided new implementation address is not of a lending market contract.
-    error LendingMarket_ImplementationAddressInvalid();
-
     // -------------------------------------------- //
     //  Modifiers                                   //
     // -------------------------------------------- //

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -76,6 +76,9 @@ contract LendingMarket is
     /// @dev Thrown when the program does not exist.
     error ProgramNotExist();
 
+    /// @dev Thrown if the provided new implementation address is not of a lending market contract.
+    error LendingMarket_ImplementationAddressInvalid();
+
     // -------------------------------------------- //
     //  Modifiers                                   //
     // -------------------------------------------- //
@@ -747,4 +750,7 @@ contract LendingMarket is
     function _blockTimestamp() internal view virtual returns (uint256) {
         return block.timestamp - Constants.NEGATIVE_TIME_OFFSET;
     }
+
+    /// @inheritdoc ILendingMarket
+    function proveLendingMarket() external pure {}
 }

--- a/contracts/LendingMarketUUPS.sol
+++ b/contracts/LendingMarketUUPS.sol
@@ -3,18 +3,25 @@
 pragma solidity 0.8.24;
 
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { UUPSExtUpgradeable } from "./common/UUPSExtUpgradeable.sol";
+
 import { LendingMarket } from "./LendingMarket.sol";
+import { ILendingMarket } from "./common/interfaces/core/ILendingMarket.sol";
 
 /// @title LendingMarketUUPS contract
 /// @author CloudWalk Inc. (See https://cloudwalk.io)
 /// @dev Upgradeable version of the lending market contract.
-contract LendingMarketUUPS is LendingMarket, UUPSUpgradeable {
+contract LendingMarketUUPS is LendingMarket, UUPSExtUpgradeable {
     /// @dev Constructor that prohibits the initialization of the implementation of the upgradable contract.
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
     }
 
-    /// @inheritdoc UUPSUpgradeable
-    function _authorizeUpgrade(address newImplementation) internal override onlyRole(OWNER_ROLE) {}
+    /// @inheritdoc UUPSExtUpgradeable
+    function _validateUpgrade(address newImplementation) internal override onlyRole(OWNER_ROLE) {
+        try ILendingMarket(newImplementation).proveLendingMarket() {} catch {
+            revert LendingMarket_ImplementationAddressInvalid();
+        }
+    }
 }

--- a/contracts/LendingMarketUUPS.sol
+++ b/contracts/LendingMarketUUPS.sol
@@ -2,11 +2,9 @@
 
 pragma solidity 0.8.24;
 
-import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import { UUPSExtUpgradeable } from "./common/UUPSExtUpgradeable.sol";
-
 import { LendingMarket } from "./LendingMarket.sol";
-import { ILendingMarket } from "./common/interfaces/core/ILendingMarket.sol";
+import { Error } from "./common/libraries/Error.sol";
 
 /// @title LendingMarketUUPS contract
 /// @author CloudWalk Inc. (See https://cloudwalk.io)
@@ -22,9 +20,9 @@ contract LendingMarketUUPS is LendingMarket, UUPSExtUpgradeable {
      * @dev The upgrade validation function for the UUPSExtUpgradeable contract.
      * @param newImplementation The address of the new implementation.
      */
-    function _validateUpgrade(address newImplementation) internal override onlyRole(OWNER_ROLE) {
-        try ILendingMarket(newImplementation).proveLendingMarket() {} catch {
-            revert LendingMarket_ImplementationAddressInvalid();
+    function _validateUpgrade(address newImplementation) internal view override onlyRole(OWNER_ROLE) {
+        try LendingMarketUUPS(newImplementation).proveLendingMarket() {} catch {
+            revert Error.ImplementationAddressInvalid();
         }
     }
 }

--- a/contracts/LendingMarketUUPS.sol
+++ b/contracts/LendingMarketUUPS.sol
@@ -18,7 +18,10 @@ contract LendingMarketUUPS is LendingMarket, UUPSExtUpgradeable {
         _disableInitializers();
     }
 
-    /// @inheritdoc UUPSExtUpgradeable
+    /**
+     * @dev The upgrade validation function for the UUPSExtUpgradeable contract.
+     * @param newImplementation The address of the new implementation.
+     */
     function _validateUpgrade(address newImplementation) internal override onlyRole(OWNER_ROLE) {
         try ILendingMarket(newImplementation).proveLendingMarket() {} catch {
             revert LendingMarket_ImplementationAddressInvalid();

--- a/contracts/common/UUPSExtUpgradeable.sol
+++ b/contracts/common/UUPSExtUpgradeable.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+/**
+ * @title UUPSExtUpgradeable base contract
+ * @author CloudWalk Inc. (See https://www.cloudwalk.io)
+ * @dev Extends the OpenZeppelin's {UUPSUpgradeable} contract by adding additional checks for
+ * the new implementation address.
+ *
+ * This contract is used through inheritance. It introduces the virtual `_validateUpgrade()` function that must be
+ * implemented in the parent contract.
+ */
+abstract contract UUPSExtUpgradeable is UUPSUpgradeable {
+    // ------------------ Errors ---------------------------------- //
+
+    /// @dev Thrown if the provided new implementation address is not a contract.
+    error UUPSExtUpgradeable_ImplementationAddressNotContract();
+
+    /// @dev Thrown if the provided new implementation contract address is zero.
+    error UUPSExtUpgradeable_ImplementationAddressZero();
+
+    // ------------------ Internal functions ---------------------- //
+
+    /**
+     * @dev The upgrade authorization function for UUPSProxy.
+     * @param newImplementation The address of the new implementation.
+     */
+    function _authorizeUpgrade(address newImplementation) internal override {
+        if (newImplementation == address(0)) {
+            revert UUPSExtUpgradeable_ImplementationAddressZero();
+        }
+
+        if (newImplementation.code.length == 0) {
+            revert UUPSExtUpgradeable_ImplementationAddressNotContract();
+        }
+
+        _validateUpgrade(newImplementation);
+    }
+
+    /**
+     * @dev Executes further validation steps of the upgrade including authorization and implementation address checks.
+     * @param newImplementation The address of the new implementation.
+     */
+    function _validateUpgrade(address newImplementation) internal virtual;
+}

--- a/contracts/common/Versionable.sol
+++ b/contracts/common/Versionable.sol
@@ -16,6 +16,6 @@ abstract contract Versionable is IVersionable {
      * @inheritdoc IVersionable
      */
     function $__VERSION() external pure returns (Version memory) {
-        return Version(1, 0, 0);
+        return Version(1, 1, 0);
     }
 }

--- a/contracts/common/interfaces/core/ICreditLine.sol
+++ b/contracts/common/interfaces/core/ICreditLine.sol
@@ -41,4 +41,7 @@ interface ICreditLine {
 
     /// @dev Returns the address of the credit line token.
     function token() external view returns (address);
+
+    /// @dev Proves the contract is the credit line one. A marker function.
+    function proveCreditLine() external pure;
 }

--- a/contracts/common/interfaces/core/ILendingMarket.sol
+++ b/contracts/common/interfaces/core/ILendingMarket.sol
@@ -281,4 +281,7 @@ interface ILendingMarket {
 
     /// @dev Returns the total number of loans taken.
     function loanCounter() external view returns (uint256);
+
+     /// @dev Proves the contract is the lending market one. A marker function.
+    function proveLendingMarket() external pure;
 }

--- a/contracts/common/interfaces/core/ILiquidityPool.sol
+++ b/contracts/common/interfaces/core/ILiquidityPool.sol
@@ -28,4 +28,8 @@ interface ILiquidityPool {
 
     /// @dev Returns the address of the liquidity pool token.
     function token() external view returns (address);
+
+     /// @dev Proves the contract is the liquidity pool one. A marker function.
+    function proveLiquidityPool() external pure;
+
 }

--- a/contracts/common/interfaces/core/ILiquidityPool.sol
+++ b/contracts/common/interfaces/core/ILiquidityPool.sol
@@ -31,5 +31,4 @@ interface ILiquidityPool {
 
      /// @dev Proves the contract is the liquidity pool one. A marker function.
     function proveLiquidityPool() external pure;
-
 }

--- a/contracts/common/libraries/Error.sol
+++ b/contracts/common/libraries/Error.sol
@@ -23,4 +23,7 @@ library Error {
 
     /// @dev Thrown when the called function is not implemented.
     error NotImplemented();
+
+    /// @dev Thrown if the provided new implementation address is not of a contract.
+    error ImplementationAddressInvalid();
 }

--- a/contracts/credit-lines/CreditLineConfigurable.sol
+++ b/contracts/credit-lines/CreditLineConfigurable.sol
@@ -86,6 +86,9 @@ contract CreditLineConfigurable is
     /// @dev Thrown when the borrower state counters or amounts would overflow their maximum values.
     error BorrowerStateOverflow();
 
+    /// @dev Thrown if the provided new implementation address is not of a credit line contract.
+    error CreditLine_ImplementationAddressInvalid();
+
     // -------------------------------------------- //
     //  Modifiers                                   //
     // -------------------------------------------- //
@@ -569,4 +572,7 @@ contract CreditLineConfigurable is
     function migrationState() external view returns (MigrationState memory) {
         return _migrationState;
     }
+
+     /// @inheritdoc ICreditLine
+    function proveCreditLine() external pure {}
 }

--- a/contracts/credit-lines/CreditLineConfigurable.sol
+++ b/contracts/credit-lines/CreditLineConfigurable.sol
@@ -86,9 +86,6 @@ contract CreditLineConfigurable is
     /// @dev Thrown when the borrower state counters or amounts would overflow their maximum values.
     error BorrowerStateOverflow();
 
-    /// @dev Thrown if the provided new implementation address is not of a credit line contract.
-    error CreditLine_ImplementationAddressInvalid();
-
     // -------------------------------------------- //
     //  Modifiers                                   //
     // -------------------------------------------- //

--- a/contracts/credit-lines/CreditLineConfigurableUUPS.sol
+++ b/contracts/credit-lines/CreditLineConfigurableUUPS.sol
@@ -2,19 +2,25 @@
 
 pragma solidity 0.8.24;
 
-import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { UUPSExtUpgradeable } from "../common/UUPSExtUpgradeable.sol";
 import { CreditLineConfigurable } from "./CreditLineConfigurable.sol";
+
+import { ICreditLine } from "../common/interfaces/core/ICreditLine.sol";
 
 /// @title CreditLineConfigurableUUPS contract
 /// @author CloudWalk Inc. (See https://cloudwalk.io)
 /// @dev Upgradeable version of the configurable credit line contract.
-contract CreditLineConfigurableUUPS is CreditLineConfigurable, UUPSUpgradeable {
+contract CreditLineConfigurableUUPS is CreditLineConfigurable, UUPSExtUpgradeable {
     /// @dev Constructor that prohibits the initialization of the implementation of the upgradable contract.
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
     }
 
-    /// @inheritdoc UUPSUpgradeable
-    function _authorizeUpgrade(address newImplementation) internal override onlyRole(OWNER_ROLE) {}
+    /// @inheritdoc UUPSExtUpgradeable
+    function _validateUpgrade(address newImplementation) internal override onlyRole(OWNER_ROLE) {
+        try ICreditLine(newImplementation).proveCreditLine() {} catch {
+            revert CreditLine_ImplementationAddressInvalid();
+        }
+    }
 }

--- a/contracts/credit-lines/CreditLineConfigurableUUPS.sol
+++ b/contracts/credit-lines/CreditLineConfigurableUUPS.sol
@@ -4,8 +4,7 @@ pragma solidity 0.8.24;
 
 import { UUPSExtUpgradeable } from "../common/UUPSExtUpgradeable.sol";
 import { CreditLineConfigurable } from "./CreditLineConfigurable.sol";
-
-import { ICreditLine } from "../common/interfaces/core/ICreditLine.sol";
+import { Error } from "../common/libraries/Error.sol";
 
 /// @title CreditLineConfigurableUUPS contract
 /// @author CloudWalk Inc. (See https://cloudwalk.io)
@@ -21,9 +20,9 @@ contract CreditLineConfigurableUUPS is CreditLineConfigurable, UUPSExtUpgradeabl
      * @dev The upgrade validation function for the UUPSExtUpgradeable contract.
      * @param newImplementation The address of the new implementation.
      */
-    function _validateUpgrade(address newImplementation) internal override onlyRole(OWNER_ROLE) {
-        try ICreditLine(newImplementation).proveCreditLine() {} catch {
-            revert CreditLine_ImplementationAddressInvalid();
+    function _validateUpgrade(address newImplementation) internal view override onlyRole(OWNER_ROLE) {
+        try CreditLineConfigurableUUPS(newImplementation).proveCreditLine() {} catch {
+            revert Error.ImplementationAddressInvalid();
         }
     }
 }

--- a/contracts/credit-lines/CreditLineConfigurableUUPS.sol
+++ b/contracts/credit-lines/CreditLineConfigurableUUPS.sol
@@ -17,7 +17,10 @@ contract CreditLineConfigurableUUPS is CreditLineConfigurable, UUPSExtUpgradeabl
         _disableInitializers();
     }
 
-    /// @inheritdoc UUPSExtUpgradeable
+    /**
+     * @dev The upgrade validation function for the UUPSExtUpgradeable contract.
+     * @param newImplementation The address of the new implementation.
+     */
     function _validateUpgrade(address newImplementation) internal override onlyRole(OWNER_ROLE) {
         try ICreditLine(newImplementation).proveCreditLine() {} catch {
             revert CreditLine_ImplementationAddressInvalid();

--- a/contracts/liquidity-pools/LiquidityPoolAccountable.sol
+++ b/contracts/liquidity-pools/LiquidityPoolAccountable.sol
@@ -65,9 +65,6 @@ contract LiquidityPoolAccountable is
     /// @dev Thrown when the token source balance is insufficient.
     error InsufficientBalance();
 
-    /// @dev Thrown if the provided new implementation address is not of a liquidity pool contract.
-    error LiquidityPool_ImplementationAddressInvalid();
-
     // -------------------------------------------- //
     //  Modifiers                                   //
     // -------------------------------------------- //

--- a/contracts/liquidity-pools/LiquidityPoolAccountable.sol
+++ b/contracts/liquidity-pools/LiquidityPoolAccountable.sol
@@ -65,6 +65,9 @@ contract LiquidityPoolAccountable is
     /// @dev Thrown when the token source balance is insufficient.
     error InsufficientBalance();
 
+    /// @dev Thrown if the provided new implementation address is not of a liquidity pool contract.
+    error LiquidityPool_ImplementationAddressInvalid();
+
     // -------------------------------------------- //
     //  Modifiers                                   //
     // -------------------------------------------- //
@@ -283,4 +286,7 @@ contract LiquidityPoolAccountable is
     function token() external view returns (address) {
         return _token;
     }
+
+    /// @inheritdoc ILiquidityPool
+    function proveLiquidityPool() external pure {}
 }

--- a/contracts/liquidity-pools/LiquidityPoolAccountableUUPS.sol
+++ b/contracts/liquidity-pools/LiquidityPoolAccountableUUPS.sol
@@ -17,7 +17,10 @@ contract LiquidityPoolAccountableUUPS is LiquidityPoolAccountable, UUPSExtUpgrad
         _disableInitializers();
     }
 
-    /// @inheritdoc UUPSExtUpgradeable
+    /**
+     * @dev The upgrade validation function for the UUPSExtUpgradeable contract.
+     * @param newImplementation The address of the new implementation.
+     */
     function _validateUpgrade(address newImplementation) internal override onlyRole(OWNER_ROLE) {
         try ILiquidityPool(newImplementation).proveLiquidityPool() {} catch {
             revert LiquidityPool_ImplementationAddressInvalid();

--- a/contracts/liquidity-pools/LiquidityPoolAccountableUUPS.sol
+++ b/contracts/liquidity-pools/LiquidityPoolAccountableUUPS.sol
@@ -2,19 +2,25 @@
 
 pragma solidity 0.8.24;
 
-import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { UUPSExtUpgradeable } from "../common/UUPSExtUpgradeable.sol";
 import { LiquidityPoolAccountable } from "./LiquidityPoolAccountable.sol";
+
+import { ILiquidityPool } from "../common/interfaces/core/ILiquidityPool.sol";
 
 /// @title LiquidityPoolAccountableUUPS contract
 /// @author CloudWalk Inc. (See https://cloudwalk.io)
 /// @dev Upgradeable version of the accountable liquidity pool contract.
-contract LiquidityPoolAccountableUUPS is LiquidityPoolAccountable, UUPSUpgradeable {
+contract LiquidityPoolAccountableUUPS is LiquidityPoolAccountable, UUPSExtUpgradeable {
     /// @dev Constructor that prohibits the initialization of the implementation of the upgradable contract.
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
     }
 
-    /// @inheritdoc UUPSUpgradeable
-    function _authorizeUpgrade(address newImplementation) internal override onlyRole(OWNER_ROLE) {}
+    /// @inheritdoc UUPSExtUpgradeable
+    function _validateUpgrade(address newImplementation) internal override onlyRole(OWNER_ROLE) {
+        try ILiquidityPool(newImplementation).proveLiquidityPool() {} catch {
+            revert LiquidityPool_ImplementationAddressInvalid();
+        }
+    }
 }

--- a/contracts/liquidity-pools/LiquidityPoolAccountableUUPS.sol
+++ b/contracts/liquidity-pools/LiquidityPoolAccountableUUPS.sol
@@ -4,8 +4,7 @@ pragma solidity 0.8.24;
 
 import { UUPSExtUpgradeable } from "../common/UUPSExtUpgradeable.sol";
 import { LiquidityPoolAccountable } from "./LiquidityPoolAccountable.sol";
-
-import { ILiquidityPool } from "../common/interfaces/core/ILiquidityPool.sol";
+import { Error } from "../common/libraries/Error.sol";
 
 /// @title LiquidityPoolAccountableUUPS contract
 /// @author CloudWalk Inc. (See https://cloudwalk.io)
@@ -21,9 +20,9 @@ contract LiquidityPoolAccountableUUPS is LiquidityPoolAccountable, UUPSExtUpgrad
      * @dev The upgrade validation function for the UUPSExtUpgradeable contract.
      * @param newImplementation The address of the new implementation.
      */
-    function _validateUpgrade(address newImplementation) internal override onlyRole(OWNER_ROLE) {
-        try ILiquidityPool(newImplementation).proveLiquidityPool() {} catch {
-            revert LiquidityPool_ImplementationAddressInvalid();
+    function _validateUpgrade(address newImplementation) internal view override onlyRole(OWNER_ROLE) {
+        try LiquidityPoolAccountableUUPS(newImplementation).proveLiquidityPool() {} catch {
+            revert Error.ImplementationAddressInvalid();
         }
     }
 }

--- a/contracts/mocks/CreditLineMock.sol
+++ b/contracts/mocks/CreditLineMock.sol
@@ -85,4 +85,6 @@ contract CreditLineMock is ICreditLine {
     function mockLoanTerms(address borrower, uint256 amount, Loan.Terms memory terms) external {
         _loanTerms[borrower][amount] = terms;
     }
+
+    function proveCreditLine() external pure {}
 }

--- a/contracts/mocks/LendingMarketMock.sol
+++ b/contracts/mocks/LendingMarketMock.sol
@@ -222,4 +222,6 @@ contract LendingMarketMock is ILendingMarket {
     function callOnAfterLoanRevocationCreditLine(address creditLine, uint256 loanId) external {
         emit HookCallResult(ICreditLine(creditLine).onAfterLoanRevocation(loanId));
     }
+
+    function proveLendingMarket() external pure {}
 }

--- a/contracts/mocks/LiquidityPoolMock.sol
+++ b/contracts/mocks/LiquidityPoolMock.sol
@@ -75,4 +75,6 @@ contract LiquidityPoolMock is ILiquidityPool {
     function approveMarket(address _market, address token_) external {
         IERC20(token_).approve(_market, type(uint56).max);
     }
+
+    function proveLiquidityPool() external pure {}
 }

--- a/contracts/mocks/UUPSExtUpgradableMock.sol
+++ b/contracts/mocks/UUPSExtUpgradableMock.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import { UUPSExtUpgradeable } from "../common/UUPSExtUpgradeable.sol";
+
+/**
+ * @title UUPSExtUpgradableMock contract
+ * @author CloudWalk Inc. (See https://www.cloudwalk.io)
+ * @dev An implementation of the {UUPSExtUpgradable} contract for test purposes.
+ */
+contract UUPSExtUpgradeableMock is UUPSExtUpgradeable {
+    /// @dev Emitted when the internal `_validateUpgrade()` function is called with the parameters of the function.
+    event MockValidateUpgradeCall(address newImplementation);
+
+    /**
+     * @dev Executes further validation steps of the upgrade including authorization and implementation address checks.
+     * @param newImplementation The address of the new implementation.
+     */
+    function _validateUpgrade(address newImplementation) internal virtual override {
+        emit MockValidateUpgradeCall(newImplementation);
+    }
+}

--- a/test/LendingMarket.base.test.ts
+++ b/test/LendingMarket.base.test.ts
@@ -124,7 +124,7 @@ const ACCURACY_FACTOR = 10000;
 const COOLDOWN_IN_PERIODS = 3;
 const EXPECTED_VERSION: Version = {
   major: 1,
-  minor: 0,
+  minor: 1,
   patch: 0
 };
 

--- a/test/LendingMarket.complex.test.ts
+++ b/test/LendingMarket.complex.test.ts
@@ -284,7 +284,6 @@ describe("Contract 'LendingMarket': complex tests", async () => {
 
       expect(actualPrecision).to.lessThanOrEqual(scenario.precision, errorMessageBefore);
       expect(actualTrackedBalanceAfter).to.eq(expectedTrackedBalanceAfter, errorMessageAfter);
-
     }
   }
 

--- a/test/LendingMarketUUPS.test.ts
+++ b/test/LendingMarketUUPS.test.ts
@@ -53,7 +53,7 @@ describe("Contract 'LendingMarketUUPS'", async () => {
     it("Is reverted if the caller is not the owner", async () => {
       const { lendingMarket } = await setUpFixture(deployLendingMarket);
 
-      await expect(connect(lendingMarket, attacker).upgradeToAndCall(attacker.address, "0x"))
+      await expect(connect(lendingMarket, attacker).upgradeToAndCall(lendingMarket, "0x"))
         .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_ACCESS_CONTROL_UNAUTHORIZED)
         .withArgs(attacker.address, OWNER_ROLE);
     });

--- a/test/LendingMarketUUPS.test.ts
+++ b/test/LendingMarketUUPS.test.ts
@@ -6,6 +6,7 @@ import { checkContractUupsUpgrading, connect } from "../test-utils/eth";
 import { setUpFixture } from "../test-utils/common";
 
 const ERROR_NAME_ACCESS_CONTROL_UNAUTHORIZED = "AccessControlUnauthorizedAccount";
+const ERROR_NAME_IMPLEMENTATION_ADDRESS_INVALID = "ImplementationAddressInvalid";
 
 const OWNER_ROLE = ethers.id("OWNER_ROLE");
 
@@ -56,6 +57,16 @@ describe("Contract 'LendingMarketUUPS'", async () => {
       await expect(connect(lendingMarket, attacker).upgradeToAndCall(lendingMarket, "0x"))
         .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_ACCESS_CONTROL_UNAUTHORIZED)
         .withArgs(attacker.address, OWNER_ROLE);
+    });
+
+    it("Is reverted if the provided implementation address is not a lending market contract", async () => {
+      const { lendingMarket } = await setUpFixture(deployLendingMarket);
+      const mockContractFactory = await ethers.getContractFactory("UUPSExtUpgradeableMock");
+      const mockContract = await mockContractFactory.deploy() as Contract;
+      await mockContract.waitForDeployment();
+
+      await expect(lendingMarket.upgradeToAndCall(mockContract, "0x"))
+        .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_IMPLEMENTATION_ADDRESS_INVALID);
     });
   });
 });

--- a/test/common/UUPSExtUbgradable.test.ts
+++ b/test/common/UUPSExtUbgradable.test.ts
@@ -1,0 +1,70 @@
+import { ethers, network, upgrades } from "hardhat";
+import { expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { connect } from "../../test-utils/eth";
+
+const ADDRESS_ZERO = ethers.ZeroAddress;
+
+async function setUpFixture<T>(func: () => Promise<T>): Promise<T> {
+  if (network.name === "hardhat") {
+    return loadFixture(func);
+  } else {
+    return func();
+  }
+}
+
+describe("Contracts 'UUPSExtUpgradeable'", async () => {
+  // Errors of the lib contracts
+  const REVERT_ERROR_IMPLEMENTATION_ADDRESS_NOT_CONTRACT = "UUPSExtUpgradeable_ImplementationAddressNotContract";
+  const REVERT_ERROR_IMPLEMENTATION_ADDRESS_ZERO = "UUPSExtUpgradeable_ImplementationAddressZero";
+
+  // Events of the contracts under test
+  const EVENT_NAME_MOCK_VALIDATE_UPGRADE_CALL = "MockValidateUpgradeCall";
+
+  let uupsExtensionFactory: ContractFactory;
+  let deployer: HardhatEthersSigner;
+
+  before(async () => {
+    [deployer] = await ethers.getSigners();
+
+    // The contract factory with the explicitly specified deployer account
+    uupsExtensionFactory = await ethers.getContractFactory("UUPSExtUpgradeableMock");
+    uupsExtensionFactory = uupsExtensionFactory.connect(deployer);
+  });
+
+  async function deployContract(): Promise<{ uupsExtension: Contract }> {
+    let uupsExtension: Contract = await upgrades.deployProxy(uupsExtensionFactory, [], { initializer: false });
+    await uupsExtension.waitForDeployment();
+    uupsExtension = connect(uupsExtension, deployer); // Explicitly specifying the initial account
+
+    return { uupsExtension };
+  }
+
+  describe("Function 'upgradeToAndCall()'", async () => {
+    it("Executes as expected", async () => {
+      const { uupsExtension } = await setUpFixture(deployContract);
+
+      const newImplementation = await uupsExtensionFactory.deploy();
+      await newImplementation.waitForDeployment();
+      const newImplementationAddress = await newImplementation.getAddress();
+
+      await expect(uupsExtension.upgradeToAndCall(newImplementationAddress, "0x"))
+        .to.emit(uupsExtension, EVENT_NAME_MOCK_VALIDATE_UPGRADE_CALL)
+        .withArgs(newImplementationAddress);
+    });
+
+    it("Is reverted if the new implementation address is zero", async () => {
+      const { uupsExtension } = await setUpFixture(deployContract);
+      await expect(uupsExtension.upgradeToAndCall(ADDRESS_ZERO, "0x"))
+        .to.be.revertedWithCustomError(uupsExtension, REVERT_ERROR_IMPLEMENTATION_ADDRESS_ZERO);
+    });
+
+    it("Is reverted if the new implementation address is not a contract", async () => {
+      const { uupsExtension } = await setUpFixture(deployContract);
+      await expect(uupsExtension.upgradeToAndCall(deployer.address, "0x"))
+        .to.be.revertedWithCustomError(uupsExtension, REVERT_ERROR_IMPLEMENTATION_ADDRESS_NOT_CONTRACT);
+    });
+  });
+});

--- a/test/credit-lines/CreditLineConfigurable.test.ts
+++ b/test/credit-lines/CreditLineConfigurable.test.ts
@@ -176,7 +176,7 @@ const DEFAULT_ADDON_AMOUNT = 321;
 const DEFAULT_REPAY_AMOUNT = 322;
 const EXPECTED_VERSION: Version = {
   major: 1,
-  minor: 0,
+  minor: 1,
   patch: 0
 };
 

--- a/test/credit-lines/CreditLineConfigurableUUPS.test.ts
+++ b/test/credit-lines/CreditLineConfigurableUUPS.test.ts
@@ -58,7 +58,7 @@ describe("Contract 'CreditLineConfigurableUUPS'", async () => {
     it("Is reverted if the caller is not the owner", async () => {
       const { creditLine } = await setUpFixture(deployCreditLine);
 
-      await expect(connect(creditLine, attacker).upgradeToAndCall(attacker.address, "0x"))
+      await expect(connect(creditLine, attacker).upgradeToAndCall(creditLine, "0x"))
         .to.be.revertedWithCustomError(creditLine, ERROR_NAME_ACCESS_CONTROL_UNAUTHORIZED)
         .withArgs(attacker.address, OWNER_ROLE);
     });

--- a/test/credit-lines/CreditLineConfigurableUUPS.test.ts
+++ b/test/credit-lines/CreditLineConfigurableUUPS.test.ts
@@ -6,6 +6,7 @@ import { checkContractUupsUpgrading, connect } from "../../test-utils/eth";
 import { setUpFixture } from "../../test-utils/common";
 
 const ERROR_NAME_ACCESS_CONTROL_UNAUTHORIZED = "AccessControlUnauthorizedAccount";
+const ERROR_NAME_IMPLEMENTATION_ADDRESS_INVALID = "ImplementationAddressInvalid";
 
 const OWNER_ROLE = ethers.id("OWNER_ROLE");
 
@@ -61,6 +62,16 @@ describe("Contract 'CreditLineConfigurableUUPS'", async () => {
       await expect(connect(creditLine, attacker).upgradeToAndCall(creditLine, "0x"))
         .to.be.revertedWithCustomError(creditLine, ERROR_NAME_ACCESS_CONTROL_UNAUTHORIZED)
         .withArgs(attacker.address, OWNER_ROLE);
+    });
+
+    it("Is reverted if the provided implementation address is not a credit line contract", async () => {
+      const { creditLine } = await setUpFixture(deployCreditLine);
+      const mockContractFactory = await ethers.getContractFactory("UUPSExtUpgradeableMock");
+      const mockContract = await mockContractFactory.deploy() as Contract;
+      await mockContract.waitForDeployment();
+
+      await expect(creditLine.upgradeToAndCall(mockContract, "0x"))
+        .to.be.revertedWithCustomError(creditLine, ERROR_NAME_IMPLEMENTATION_ADDRESS_INVALID);
     });
   });
 });

--- a/test/liquidity-pools/LiquidityPoolAccountable.test.ts
+++ b/test/liquidity-pools/LiquidityPoolAccountable.test.ts
@@ -64,7 +64,7 @@ const AUTO_REPAY_LOAN_IDS = [1, 2, 3];
 const AUTO_REPAY_AMOUNTS = [4, 5, 6];
 const EXPECTED_VERSION: Version = {
   major: 1,
-  minor: 0,
+  minor: 1,
   patch: 0
 };
 

--- a/test/liquidity-pools/LiquidityPoolAccountableUUPS.test.ts
+++ b/test/liquidity-pools/LiquidityPoolAccountableUUPS.test.ts
@@ -56,7 +56,7 @@ describe("Contract 'LiquidityPoolAccountableUUPS'", async () => {
     it("Is reverted if the caller is not the owner", async () => {
       const { liquidityPool } = await setUpFixture(deployLiquidityPool);
 
-      await expect(connect(liquidityPool, attacker).upgradeToAndCall(attacker.address, "0x"))
+      await expect(connect(liquidityPool, attacker).upgradeToAndCall(liquidityPool, "0x"))
         .to.be.revertedWithCustomError(liquidityPool, ERROR_NAME_ACCESS_CONTROL_UNAUTHORIZED)
         .withArgs(attacker.address, OWNER_ROLE);
     });

--- a/test/liquidity-pools/LiquidityPoolAccountableUUPS.test.ts
+++ b/test/liquidity-pools/LiquidityPoolAccountableUUPS.test.ts
@@ -6,6 +6,7 @@ import { checkContractUupsUpgrading, connect } from "../../test-utils/eth";
 import { setUpFixture } from "../../test-utils/common";
 
 const ERROR_NAME_ACCESS_CONTROL_UNAUTHORIZED = "AccessControlUnauthorizedAccount";
+const ERROR_NAME_IMPLEMENTATION_ADDRESS_INVALID = "ImplementationAddressInvalid";
 
 const OWNER_ROLE = ethers.id("OWNER_ROLE");
 
@@ -59,6 +60,16 @@ describe("Contract 'LiquidityPoolAccountableUUPS'", async () => {
       await expect(connect(liquidityPool, attacker).upgradeToAndCall(liquidityPool, "0x"))
         .to.be.revertedWithCustomError(liquidityPool, ERROR_NAME_ACCESS_CONTROL_UNAUTHORIZED)
         .withArgs(attacker.address, OWNER_ROLE);
+    });
+
+    it("Is reverted if the provided implementation address is not a liquidity pool contract", async () => {
+      const { liquidityPool } = await setUpFixture(deployLiquidityPool);
+      const mockContractFactory = await ethers.getContractFactory("UUPSExtUpgradeableMock");
+      const mockContract = await mockContractFactory.deploy() as Contract;
+      await mockContract.waitForDeployment();
+
+      await expect(liquidityPool.upgradeToAndCall(mockContract, "0x"))
+        .to.be.revertedWithCustomError(liquidityPool, ERROR_NAME_IMPLEMENTATION_ADDRESS_INVALID);
     });
   });
 });

--- a/test/mocks/CreditLineMock.test.ts
+++ b/test/mocks/CreditLineMock.test.ts
@@ -35,6 +35,12 @@ describe("Contract 'CreditLineMock'", async () => {
 
       expect(await creditLine.token()).to.eq(ethers.ZeroAddress);
     });
+
+    it("Function 'proveCreditLine()'", async () => {
+      const { creditLine } = await setUpFixture(deployCreditLine);
+
+      expect(await creditLine.proveCreditLine()).to.exist;
+    });
   });
 
   describe("Unimplemented mock functions are reverted as expected", async () => {

--- a/test/mocks/LendingMarketMock.test.ts
+++ b/test/mocks/LendingMarketMock.test.ts
@@ -34,6 +34,11 @@ describe("Contract 'LendingMarketMock'", async () => {
   }
 
   describe("Cover unused functions", async () => {
+    it("Function 'proveCreditLine()'", async () => {
+      const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
+
+      expect(await lendingMarket.proveLendingMarket()).to.exist;
+    });
   });
 
   describe("Unimplemented mock functions are reverted as expected", async () => {

--- a/test/mocks/LiquidityPoolMock.test.ts
+++ b/test/mocks/LiquidityPoolMock.test.ts
@@ -30,6 +30,14 @@ describe("Contract 'LiquidityPoolMock'", async () => {
     };
   }
 
+  describe("Cover unused functions", async () => {
+    it("Function 'proveCreditLine()'", async () => {
+      const { liquidityPool } = await setUpFixture(deployLiquidityPool);
+
+      expect(await liquidityPool.proveLiquidityPool()).to.exist;
+    });
+  });
+
   describe("Unimplemented mock functions are reverted as expected", async () => {
     it("Function 'market()'", async () => {
       const { liquidityPool } = await setUpFixture(deployLiquidityPool);


### PR DESCRIPTION
## Main changes

1. The new `UUPSExtUpgradeable` contract has been introduced for internal usage through inheritance.
2. The new contract provides additional checks during the upgrade, making the procedure safer.
3. A new marker functions named `proveLendingMarket()`, `proveCreditLine()` and `proveLiquidityPool()` has been added to the `LendingMarket`, `CreditLineConfigurable` and `LiquidityPoolAccountable` contracts correspondingly  for use in conjunction with the new `UUPSExtUpgradeable` contract. When upgrading, that function ensures that the new implementation of a contract is compatible.

## Versioning 

The version of the `LendingMarket`, `CreditLineConfigurable` and `LiquidityPoolAccountable` contracts has been changed: `1.0.0` => `1.1.0`.

## Test coverage

New functionality was fully covered by tests.