### PR TITLE
feat: introduce the external addon treasury

### DIFF
--- a/contracts/common/interfaces/ILiquidityPoolAccountable.sol
+++ b/contracts/common/interfaces/ILiquidityPoolAccountable.sol
@@ -12,6 +12,14 @@ interface ILiquidityPoolAccountable is ILiquidityPool {
     //  Events                                      //
     // -------------------------------------------- //
 
+    /// @dev Emitted when the the addon treasury address has been changed.
+    ///
+    /// See the {addonTreasury} function comments for more details.
+    ///
+    /// @param newTreasury The updated address of the addon treasury.
+    /// @param oldTreasury The previous address of the addon treasury.
+    event AddonTreasuryChanged(address newTreasury, address oldTreasury);
+
     /// @dev Emitted when tokens are deposited to the liquidity pool.
     /// @param amount The amount of tokens deposited.
     event Deposit(uint256 amount);
@@ -48,12 +56,24 @@ interface ILiquidityPoolAccountable is ILiquidityPool {
     /// @param amount The amount of tokens to rescue.
     function rescue(address token, uint256 amount) external;
 
+    /// @dev Sets the addon treasury address.
+    ///
+    /// See the {addonTreasury} function comments for more details.
+    ///
+    /// @param newTreasury The new address of the addon treasury to set.
+    function setAddonTreasury(address newTreasury) external;
+
     /// @dev Executes auto repayment of loans in the batch mode.
     /// @param loanIds The unique identifiers of the loans to repay.
     /// @param amounts The payment amounts that correspond with given loan ids.
     function autoRepay(uint256[] memory loanIds, uint256[] memory amounts) external;
 
     /// @dev Gets the borrowable and addons balances of the liquidity pool.
+    ///
+    /// The addons part of the balance is changes only if the addon amount of loans is retained on the pool contract.
+    /// If the addon amount of loans transfers to an external addon treasury that part is kept unchanged.
+    /// See the {addonTreasury} function comments for more details.
+    ///
     /// @return The borrowable and addons balances.
     function getBalances() external view returns (uint256, uint256);
 
@@ -61,4 +81,12 @@ interface ILiquidityPoolAccountable is ILiquidityPool {
     /// @param account The address of the account to check.
     /// @return True if the account is configured as an admin.
     function isAdmin(address account) external view returns (bool);
+
+    /// @dev Returns the addon treasury address.
+    ///
+    /// If the address is zero the addon amount of a loan is retained in the pool.
+    /// Otherwise the addon amount transfers to that treasury when a loan is taken and back when a loan is revoked.
+    ///
+    /// @return The current address of the addon treasury.
+    function addonTreasury() external view returns (address);
 }

--- a/contracts/liquidity-pools/LiquidityPoolAccountable.sol
+++ b/contracts/liquidity-pools/LiquidityPoolAccountable.sol
@@ -334,7 +334,9 @@ contract LiquidityPoolAccountable is
         if (newTreasury == address(0)) {
             revert AddonTreasuryAddressZeroingProhibited();
         }
-        _checkAddonTreasuryAllowance(newTreasury);
+        if (IERC20(_token).allowance(newTreasury, address(this)) == 0) {
+            revert AddonTreasuryZeroAllowance();
+        }
         emit AddonTreasuryChanged(newTreasury, oldTreasury);
         _addonTreasury = newTreasury;
     }
@@ -360,14 +362,6 @@ contract LiquidityPoolAccountable is
             _addonsBalance -= addonAmount;
         } else {
             IERC20(_token).safeTransferFrom(addonTreasury_, address(this), addonAmount);
-        }
-    }
-
-    /// @dev Checks whether an addon treasury has provided an allowance for the pool contract to transfer its tokens.
-    function _checkAddonTreasuryAllowance(address addonTreasury_) internal view {
-        uint256 allowance = IERC20(_token).allowance(addonTreasury_, address(this));
-        if (allowance == 0) {
-            revert AddonTreasuryZeroAllowance();
         }
     }
 }

--- a/contracts/liquidity-pools/LiquidityPoolAccountable.sol
+++ b/contracts/liquidity-pools/LiquidityPoolAccountable.sol
@@ -52,7 +52,17 @@ contract LiquidityPoolAccountable is
     uint64 internal _borrowableBalance;
 
     /// @dev The addons balance of the liquidity pool.
+    ///
+    /// It is used only if the addon amount of loans is retained on the pool contract.
+    /// If the addon amount of loans transfers to an external addon treasury this variable is kept unchanged.
+    /// See the comments of the {_addonTreasury} storage variable for more details.
     uint64 internal _addonsBalance;
+
+    /// @dev The address of the addon treasury.
+    ///
+    /// If the address is zero the addon amount of a loan is retained in the pool.
+    /// Otherwise the addon amount transfers to that treasury when a loan is taken and back when a loan is revoked.
+    address internal _addonTreasury;
 
     /// @dev This empty reserved space is put in place to allow future versions
     /// to add new variables without shifting down storage in the inheritance chain.
@@ -61,6 +71,16 @@ contract LiquidityPoolAccountable is
     // -------------------------------------------- //
     //  Errors                                      //
     // -------------------------------------------- //
+
+    /// @dev Thrown when attempting to zero the addon treasury address.
+    ///
+    /// Zeroing the addon treasury address is prohibited because this can lead to a situation where
+    /// a loan is taken when it is non-zero and revoked when it is zero, which will lead to
+    /// an incorrect value of the `_addonsBalance` variable, or a reversion if `_addonsBalance == 0`.
+    error AddonTreasuryAddressZeroingProhibited();
+
+    /// @dev Thrown when the addon treasury has not provided an allowance for the pool contract to transfer its tokens.
+    error AddonTreasuryZeroAllowance();
 
     /// @dev Thrown when the token source balance is insufficient.
     error InsufficientBalance();
@@ -211,6 +231,11 @@ contract LiquidityPoolAccountable is
         emit Rescue(token_, amount);
     }
 
+    /// @inheritdoc ILiquidityPoolAccountable
+    function setAddonTreasury(address newTreasury) external onlyRole(OWNER_ROLE) {
+        _setAddonTreasury(newTreasury);
+    }
+
     // -------------------------------------------- //
     //  Admin functions                             //
     // -------------------------------------------- //
@@ -237,7 +262,7 @@ contract LiquidityPoolAccountable is
     function onBeforeLoanTaken(uint256 loanId) external whenNotPaused onlyMarket returns (bool) {
         Loan.State memory loan = ILendingMarket(_market).getLoanState(loanId);
         _borrowableBalance -= loan.borrowAmount + loan.addonAmount;
-        _addonsBalance += loan.addonAmount;
+        _collectLoanAddon(loan.addonAmount);
         return true;
     }
 
@@ -256,7 +281,7 @@ contract LiquidityPoolAccountable is
         } else {
             _borrowableBalance = _borrowableBalance - (loan.repaidAmount - loan.borrowAmount) + loan.addonAmount;
         }
-        _addonsBalance -= loan.addonAmount;
+        _revokeLoanAddon(loan.addonAmount);
         return true;
     }
 
@@ -284,6 +309,65 @@ contract LiquidityPoolAccountable is
         return _token;
     }
 
+    /// @dev ILiquidityPool
+    function addonTreasury() external view returns (address) {
+        return _addonTreasury;
+    }
+
+    // -------------------------------------------- //
+    //  Pure functions                              //
+    // -------------------------------------------- //
+
     /// @inheritdoc ILiquidityPool
     function proveLiquidityPool() external pure {}
+
+    // -------------------------------------------- //
+    //  Internal functions                          //
+    // -------------------------------------------- //
+
+    /// @dev Sets the new address of the  addon treasury internally.
+    function _setAddonTreasury(address newTreasury) internal {
+        address oldTreasury = _addonTreasury;
+        if (oldTreasury == newTreasury) {
+            revert Error.AlreadyConfigured();
+        }
+        if (newTreasury == address(0)) {
+            revert AddonTreasuryAddressZeroingProhibited();
+        }
+        _checkAddonTreasuryAllowance(newTreasury);
+        emit AddonTreasuryChanged(newTreasury, oldTreasury);
+        _addonTreasury = newTreasury;
+    }
+
+    /// @dev Collects the addon amount depending on the addon treasury address.
+    ///
+    /// See the comments of the {_addonTreasury} storage variable for more details.
+    function _collectLoanAddon(uint64 addonAmount) internal {
+        address addonTreasury_ = _addonTreasury;
+        if (addonTreasury_ == address(0)) {
+            _addonsBalance += addonAmount;
+        } else {
+            IERC20(_token).safeTransfer(addonTreasury_, addonAmount);
+        }
+    }
+
+    /// @dev Revokes the addon amount depending on the addon treasury address.
+    ///
+    /// See the comments of the {_addonTreasury} storage variable for more details.
+    function _revokeLoanAddon(uint64 addonAmount) internal {
+        address addonTreasury_ = _addonTreasury;
+        if (addonTreasury_ == address(0)) {
+            _addonsBalance -= addonAmount;
+        } else {
+            IERC20(_token).safeTransferFrom(addonTreasury_, address(this), addonAmount);
+        }
+    }
+
+    /// @dev Checks whether an addon treasury has provided an allowance for the pool contract to transfer its tokens.
+    function _checkAddonTreasuryAllowance(address addonTreasury_) internal view {
+        uint256 allowance = IERC20(_token).allowance(addonTreasury_, address(this));
+        if (allowance == 0) {
+            revert AddonTreasuryZeroAllowance();
+        }
+    }
 }


### PR DESCRIPTION
## Main changes
1. The ability to configure the external treasury address for collecting addon amounts of loans has been added to the liquidity pool contract.
2. If the addon treasury address is not zero the addon amount transfers to that treasury when a loan is taken and back when a loan is revoked.
3. If the addon treasury address is zero the old logic is applied and the addon amount of a loan is retained in the pool.
4. In the current implementation, only the transition from `zero` to `non-zero` is allowed for the addon treasury address, but not backward. This is done to prevent an incorrect value of the `_addonsBalance` variable of the liquidity pool or a transaction reversion if `_addonsBalance == 0` when the backward switch happens between  taking a loan and revoking it. If a backward switch is necessary, this can only be done by a new pool deployment, or by modifying the source code of the existing one.

## Addon Treasury Configuration
The recommended sequence for initial setting a non-zero address for the addon treasury:
1. Withdraw 50% of the tokens from the pool using the addon balance.
2. Transfer these tokens to the addon treasury account.
3. Set the addon treasury address in the pool.
4. Withdraw the remaining tokens from the pool using the addon balance.
5. Transfer these tokens to the addon treasury account.

## Test Coverage
The new logic is fully covered by tests.
Additional improvements have been made in complex tests.

<details>

<summary>Test coverage details</summary>

| File                                    |  % Stmts | % Branch |  % Funcs |  % Lines |
|-----------------------------------------|---------:|---------:|---------:|---------:|
| contracts/                              |   100.00 |    98.19 |   100.00 |   100.00 |
| ├─ LendingMarket.sol                    |   100.00 |    98.17 |   100.00 |   100.00 |
| ├─ LendingMarketStorage.sol             |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketUUPS.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/                       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeable.sol      |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/interfaces/            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICreditLineConfigurable.sol          |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILiquidityPoolAccountable.sol        |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/interfaces/core/       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICreditLine.sol                      |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILendingMarket.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILiquidityPool.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/libraries/             |   100.00 |    68.00 |   100.00 |    98.86 |
| ├─ ABDKMath64x64.sol                    |   100.00 |    63.64 |   100.00 |    98.63 |
| ├─ Constants.sol                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Error.sol                            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ InterestMath.sol                     |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Loan.sol                             |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Round.sol                            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ SafeCast.sol                         |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/credit-lines/                 |   100.00 |    97.37 |   100.00 |   100.00 |
| ├─ CreditLineConfigurable.sol           |   100.00 |    97.32 |   100.00 |   100.00 |
| ├─ CreditLineConfigurableUUPS.sol       |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/liquidity-pools/              |   100.00 |    97.22 |   100.00 |   100.00 |
| ├─ LiquidityPoolAccountable.sol         |   100.00 |    97.14 |   100.00 |   100.00 |
| ├─ LiquidityPoolAccountableUUPS.sol     |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/mocks/                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeableMock.sol  |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineMock.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ERC20Mock.sol                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketMock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPoolMock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/testables/                    |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineConfigurableTestable.sol   |   100.00 |   100.00 |   100.00 |   100.00 |
|-----------------------------------------|----------|----------|----------|----------|
| All files                               |   100.00 |    94.23 |   100.00 |    99.85 |
|-----------------------------------------|----------|----------|----------|----------|
</details>


