### PR TITLE
feat: introduce installments feature

### DIFF
--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -875,8 +875,8 @@ contract LendingMarket is
     /// @param durationsInPeriods Array of loan durations in periods.
     function _checkDurationArray(uint256[] calldata durationsInPeriods) internal pure {
         uint256 len = durationsInPeriods.length;
-        uint256 previousDuration = 0;
-        for (uint256 i = 0; i < len; ++i) {
+        uint256 previousDuration = durationsInPeriods[0];
+        for (uint256 i = 1; i < len; ++i) {
             uint256 duration = durationsInPeriods[i];
             if (duration < previousDuration) {
                 revert DurationArrayInvalid();

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -202,7 +202,7 @@ contract LendingMarket is
         uint256[] calldata borrowAmounts,
         uint256[] calldata addonAmounts,
         uint256[] calldata durationInPeriods
-    ) external whenNotPaused returns (uint256 firstInstallmentId, uint256 installmentCount)  {
+    ) external whenNotPaused returns (uint256 firstInstallmentId, uint256 installmentCount) {
         uint256 totalBorrowAmount = _sumArray(borrowAmounts);
         uint256 totalAddonAmount = _sumArray(addonAmounts);
         installmentCount = borrowAmounts.length;
@@ -855,7 +855,7 @@ contract LendingMarket is
 
     /// @dev TODO
     function _updateLoanInstallmentData(
-        uint256 loanId,
+        uint256 loanId, // Tools: this comment prevents Prettier from formatting into a single line.
         uint256 firstInstallmentId,
         uint256 installmentCount
     ) internal {
@@ -865,7 +865,7 @@ contract LendingMarket is
     }
 
     /// @dev TODO
-    function _checkLoanId(uint256 id) internal pure{
+    function _checkLoanId(uint256 id) internal pure {
         if (id > type(uint40).max) {
             revert LoanIdExcess();
         }
@@ -936,10 +936,7 @@ contract LendingMarket is
     }
 
     /// @dev TODO
-    function _getDuePeriodIndex(
-        uint256 startTimestamp,
-        uint256 durationInPeriods
-    ) internal pure returns (uint256) {
+    function _getDuePeriodIndex(uint256 startTimestamp, uint256 durationInPeriods) internal pure returns (uint256) {
         uint256 startPeriodIndex = _periodIndex(startTimestamp, Constants.PERIOD_IN_SECONDS);
         return startPeriodIndex + durationInPeriods;
     }

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -887,8 +887,8 @@ contract LendingMarket is
 
     /// @dev Ensures the installment count is within the valid range.
     /// @param installmentCount The number of installments to check.
-    function _checkInstallmentCount(uint256 installmentCount) internal pure {
-        if (installmentCount > type(uint16).max) {
+    function _checkInstallmentCount(uint256 installmentCount) internal view {
+        if (installmentCount > _installmentCountMax()) {
             revert InstallmentCountExcess();
         }
     }
@@ -1062,6 +1062,11 @@ contract LendingMarket is
     /// @dev Returns the current block timestamp with the time offset applied.
     function _blockTimestamp() internal view virtual returns (uint256) {
         return block.timestamp - Constants.NEGATIVE_TIME_OFFSET;
+    }
+
+    /// @dev
+    function _installmentCountMax() internal view virtual returns (uint256) {
+        return Constants.INSTALLMENT_COUNT_MAX;
     }
 
     /// @inheritdoc ILendingMarket

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -166,7 +166,7 @@ contract LendingMarket is
         uint256 borrowAmount,
         uint256 durationInPeriods
     ) external whenNotPaused returns (uint256) {
-        address borrower = _msgSender();
+        address borrower = msg.sender;
         _checkMainLoanParameters(borrower, programId, borrowAmount, 0);
         return
             _takeLoan(

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -862,7 +862,7 @@ contract LendingMarket is
     function _sumArray(uint256[] calldata values) internal pure returns (uint256) {
         uint256 len = values.length;
         uint256 sum = 0;
-        for (uint256 i = 0; i < len; ++len) {
+        for (uint256 i = 0; i < len; ++i) {
             sum += values[i];
         }
         return sum;

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -218,6 +218,9 @@ contract LendingMarket is
         _checkMainLoanParameters(borrower, programId, totalBorrowAmount, totalAddonAmount);
         _checkDurationArray(durationsInPeriods);
         _checkInstallmentCount(installmentCount);
+        if (addonAmounts.length != installmentCount || durationsInPeriods.length != installmentCount) {
+            revert Error.ArrayLengthMismatch();
+        }
         // Arrays are not checked for emptiness because if the loan amount is zero, the transaction is reverted earlier
 
         for (uint256 i = 0; i < installmentCount; ++i) {

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -60,11 +60,10 @@ contract LendingMarket is
     /// @dev Thrown when the loan is already frozen.
     error LoanAlreadyFrozen();
 
-    /// @dev Thrown when the loan is common but another type of loan is expected.
-    error LoanIsCommon();
-
-    /// @dev Thrown when the loan is an installment one but another type of loan is expected.
-    error LoanWithInstallments();
+    /// @dev Thrown when the loan type according to the provided ID does not match the expected one.
+    /// @param actualType The actual type of the loan.
+    /// @param expectedType The expected type of the loan.
+    error LoanTypeUnexpected(Loan.Type actualType, Loan.Type expectedType);
 
     /// @dev Thrown when the credit line is not configured.
     error CreditLineLenderNotConfigured();
@@ -942,11 +941,11 @@ contract LendingMarket is
     function _checkLoanType(Loan.State storage loan, uint256 loanType) internal view {
         if (loan.instalmentCount == 0) {
             if (loanType != uint256(Loan.Type.Common)) {
-                revert LoanIsCommon();
+                revert LoanTypeUnexpected(Loan.Type(loanType), Loan.Type.Common);
             }
         } else {
             if (loanType != uint256(Loan.Type.Installment)) {
-                revert LoanWithInstallments();
+                revert LoanTypeUnexpected(Loan.Type(loanType), Loan.Type.Installment);
             }
         }
     }

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -25,6 +25,8 @@ import { LendingMarketStorage } from "./LendingMarketStorage.sol";
 /// @title LendingMarket contract
 /// @author CloudWalk Inc. (See https://cloudwalk.io)
 /// @dev Implementation of the lending market contract.
+///
+/// See additional notes in the comments of the interface `ILendingMarket.sol`.
 contract LendingMarket is
     LendingMarketStorage,
     Initializable,
@@ -43,7 +45,7 @@ contract LendingMarket is
     //  Errors                                      //
     // -------------------------------------------- //
 
-    /// @dev TODO
+    /// @dev Thrown when the loan ID exceeds the maximum allowed value.
     error LoanIdExcess();
 
     /// @dev Thrown when the loan does not exist.
@@ -79,10 +81,10 @@ contract LendingMarket is
     /// @dev Thrown when the provided address does not belong to a contract of expected type or a contract at all.
     error ContractAddressInvalid();
 
-    /// @dev TODO
+    /// @dev Thrown when the provided duration array is invalid.
     error DurationArrayInvalid();
 
-    /// @dev TODO
+    /// @dev Thrown when the installment count exceeds the maximum allowed value.
     error InstallmentCountExcess();
 
     // -------------------------------------------- //
@@ -793,7 +795,11 @@ contract LendingMarket is
     //  Internal functions                          //
     // -------------------------------------------- //
 
-    /// @dev TODO
+    /// @dev Validates the main parameters of the loan.
+    /// @param borrower The address of the borrower.
+    /// @param programId The ID of the lending program.
+    /// @param borrowAmount The amount to borrow.
+    /// @param addonAmount The addon amount of the loan.
     function _checkMainLoanParameters(
         address borrower,
         uint32 programId,
@@ -817,24 +823,29 @@ contract LendingMarket is
         }
     }
 
-    /// @dev TODO
+    /// @dev Checks if the sender is authorized for the given program.
+    /// @param sender The address to check.
+    /// @param programId The ID of the lending program.
     function _checkSender(address sender, uint32 programId) internal view {
         if (!isProgramLenderOrAlias(programId, sender)) {
             revert Error.Unauthorized();
         }
     }
 
-    /// @dev TODO
-    function _sumArray(uint256[] calldata amounts) internal pure returns (uint256) {
-        uint256 len = amounts.length;
+    /// @dev Calculates the sum of all elements in an calldata array.
+    /// @param values Array of amounts to sum.
+    /// @return The total sum of all array elements.
+    function _sumArray(uint256[] calldata values) internal pure returns (uint256) {
+        uint256 len = values.length;
         uint256 sum = 0;
         for (uint256 i = 0; i < len; ++len) {
-            sum += amounts[i];
+            sum += values[i];
         }
         return sum;
     }
 
-    /// @dev TODO
+    /// @dev Validates the loan durations in the array.
+    /// @param durationInPeriods Array of loan durations in periods.
     function _checkDurationArray(uint256[] calldata durationInPeriods) internal pure {
         uint256 len = durationInPeriods.length;
         uint256 previousDuration = 0;
@@ -846,14 +857,18 @@ contract LendingMarket is
         }
     }
 
-    /// @dev TODO
+    /// @dev Ensures the installment count is within the valid range.
+    /// @param installmentCount The number of installments to check.
     function _checkInstallmentCount(uint256 installmentCount) internal pure {
         if (installmentCount > type(uint16).max) {
             revert InstallmentCountExcess();
         }
     }
 
-    /// @dev TODO
+    /// @dev Updates the loan installment data in storage.
+    /// @param loanId The ID of the loan to update.
+    /// @param firstInstallmentId The ID of the first installment.
+    /// @param installmentCount The total number of installments.
     function _updateLoanInstallmentData(
         uint256 loanId, // Tools: this comment prevents Prettier from formatting into a single line.
         uint256 firstInstallmentId,
@@ -864,7 +879,8 @@ contract LendingMarket is
         loan.instalmentCount = uint16(installmentCount); // Unchecked conversion is safe due to contract logic
     }
 
-    /// @dev TODO
+    /// @dev Validates that the loan ID is within the valid range.
+    /// @param id The loan ID to check.
     function _checkLoanId(uint256 id) internal pure {
         if (id > type(uint40).max) {
             revert LoanIdExcess();
@@ -924,7 +940,10 @@ contract LendingMarket is
         }
     }
 
-    /// @dev TODO
+    /// @dev Calculates the loan preview.
+    /// @param loanId The ID of the loan.
+    /// @param timestamp The timestamp to calculate the preview at.
+    /// @return The loan preview.
     function _getLoanPreview(uint256 loanId, uint256 timestamp) internal view returns (Loan.Preview memory) {
         Loan.Preview memory preview;
         Loan.State storage loan = _loans[loanId];
@@ -935,13 +954,20 @@ contract LendingMarket is
         return preview;
     }
 
-    /// @dev TODO
+    /// @dev Calculates the due period index for a loan.
+    /// @param startTimestamp The start timestamp of the loan.
+    /// @param durationInPeriods The duration of the loan in periods.
+    /// @return The due period index.
     function _getDuePeriodIndex(uint256 startTimestamp, uint256 durationInPeriods) internal pure returns (uint256) {
         uint256 startPeriodIndex = _periodIndex(startTimestamp, Constants.PERIOD_IN_SECONDS);
         return startPeriodIndex + durationInPeriods;
     }
 
-    /// @dev TODO
+    /// @dev Checks if a loan is defaulted.
+    /// @param timestamp The timestamp to check.
+    /// @param startTimestamp The start timestamp of the loan.
+    /// @param durationInPeriods The duration of the loan in periods.
+    /// @return True if the loan is defaulted, false otherwise.
     function _isLoanDefaulted(
         uint256 timestamp,
         uint256 startTimestamp,

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -208,7 +208,7 @@ contract LendingMarket is
         uint32 programId,
         uint256[] calldata borrowAmounts,
         uint256[] calldata addonAmounts,
-        uint256[] calldata durationInPeriods
+        uint256[] calldata durationsInPeriods
     ) external whenNotPaused returns (uint256 firstInstallmentId, uint256 installmentCount) {
         uint256 totalBorrowAmount = _sumArray(borrowAmounts);
         uint256 totalAddonAmount = _sumArray(addonAmounts);
@@ -216,7 +216,7 @@ contract LendingMarket is
 
         _checkSender(_msgSender(), programId);
         _checkMainLoanParameters(borrower, programId, totalBorrowAmount, totalAddonAmount);
-        _checkDurationArray(durationInPeriods);
+        _checkDurationArray(durationsInPeriods);
         _checkInstallmentCount(installmentCount);
         // Arrays are not checked for emptiness because if the loan amount is zero, the transaction is reverted earlier
 
@@ -226,7 +226,7 @@ contract LendingMarket is
                 programId,
                 borrowAmounts[i],
                 int256(addonAmounts[i]),
-                durationInPeriods[i]
+                durationsInPeriods[i]
             );
             if (i == 0) {
                 firstInstallmentId = loanId;
@@ -869,12 +869,12 @@ contract LendingMarket is
     }
 
     /// @dev Validates the loan durations in the array.
-    /// @param durationInPeriods Array of loan durations in periods.
-    function _checkDurationArray(uint256[] calldata durationInPeriods) internal pure {
-        uint256 len = durationInPeriods.length;
+    /// @param durationsInPeriods Array of loan durations in periods.
+    function _checkDurationArray(uint256[] calldata durationsInPeriods) internal pure {
+        uint256 len = durationsInPeriods.length;
         uint256 previousDuration = 0;
         for (uint256 i = 0; i < len; ++i) {
-            uint256 duration = durationInPeriods[i];
+            uint256 duration = durationsInPeriods[i];
             if (duration < previousDuration) {
                 revert DurationArrayInvalid();
             }

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -587,7 +587,7 @@ contract LendingMarket is
     /// @inheritdoc ILendingMarket
     function revokeLoan(uint256 loanId) external whenNotPaused onlyOngoingLoan(loanId) {
         Loan.State storage loan = _loans[loanId];
-        _checkLoanType(loan, uint256(Loan.Type.Common));
+        _checkLoanType(loan, uint256(Loan.Type.Ordinary));
         _revokeLoan(loanId, loan);
     }
 
@@ -943,9 +943,9 @@ contract LendingMarket is
     /// @param expectedLoanType The expected type of the loan according to the `Loan.Type` enum.
     function _checkLoanType(Loan.State storage loan, uint256 expectedLoanType) internal view {
         if (loan.instalmentCount == 0) {
-            if (expectedLoanType != uint256(Loan.Type.Common)) {
+            if (expectedLoanType != uint256(Loan.Type.Ordinary)) {
                 revert LoanTypeUnexpected(
-                    Loan.Type.Common, // actual
+                    Loan.Type.Ordinary, // actual
                     Loan.Type.Installment // expected
                 );
             }
@@ -953,7 +953,7 @@ contract LendingMarket is
             if (expectedLoanType != uint256(Loan.Type.Installment)) {
                 revert LoanTypeUnexpected(
                     Loan.Type.Installment, // actual
-                    Loan.Type.Common // expected
+                    Loan.Type.Ordinary // expected
                 );
             }
         }

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -601,7 +601,7 @@ contract LendingMarket is
         uint256 lastLoanId = loanId + loan.instalmentCount - 1;
         uint256 ongoingSubLoanCount = 0;
 
-        for(; loanId <= lastLoanId; ++loanId) {
+        for (; loanId <= lastLoanId; ++loanId) {
             loan = _loans[loanId];
             if (!_isRepaid(loan)) {
                 ++ongoingSubLoanCount;
@@ -615,7 +615,7 @@ contract LendingMarket is
         }
 
         emit InstallmentLoanRevoked(
-            loan.firstInstallmentId,
+            loan.firstInstallmentId, // Tools: this comment prevents Prettier from formatting into a single line.
             loan.instalmentCount
         );
     }
@@ -916,7 +916,7 @@ contract LendingMarket is
     }
 
     /// @dev Checks if the loan can be revoked.
-    /// @param loan The storage state of the loan.  
+    /// @param loan The storage state of the loan.
     function _checkLoanRevocationPossibility(Loan.State storage loan) internal view {
         address sender = msg.sender;
         if (sender == loan.borrower) {

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -1029,24 +1029,6 @@ contract LendingMarket is
         return startPeriodIndex + durationInPeriods;
     }
 
-    /// @dev Checks if a loan is defaulted.
-    /// @param timestamp The timestamp to check.
-    /// @param startTimestamp The start timestamp of the loan.
-    /// @param durationInPeriods The duration of the loan in periods.
-    /// @return True if the loan is defaulted, false otherwise.
-    function _isLoanDefaulted(
-        uint256 timestamp,
-        uint256 startTimestamp,
-        uint256 durationInPeriods
-    ) internal pure returns (bool) {
-        uint256 duePeriodIndex = _getDuePeriodIndex(startTimestamp, durationInPeriods);
-        uint256 currentPeriodIndex = _periodIndex(timestamp, Constants.PERIOD_IN_SECONDS);
-        if (currentPeriodIndex > duePeriodIndex) {
-            return true;
-        }
-        return false;
-    }
-
     /// @dev Checks if the loan is repaid.
     /// @param loan The storage state of the loan.
     /// @return True if the loan is repaid, false otherwise.

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -190,7 +190,7 @@ contract LendingMarket is
         uint256 addonAmount,
         uint256 durationInPeriods
     ) external whenNotPaused returns (uint256) {
-        _checkSender(_msgSender(), programId);
+        _checkSender(msg.sender, programId);
         _checkMainLoanParameters(borrower, programId, borrowAmount, addonAmount);
         return
             _takeLoan(
@@ -214,7 +214,7 @@ contract LendingMarket is
         uint256 totalAddonAmount = _sumArray(addonAmounts);
         installmentCount = borrowAmounts.length;
 
-        _checkSender(_msgSender(), programId);
+        _checkSender(msg.sender, programId);
         _checkMainLoanParameters(borrower, programId, totalBorrowAmount, totalAddonAmount);
         _checkDurationArray(durationsInPeriods);
         _checkInstallmentCount(installmentCount);

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -203,6 +203,7 @@ contract LendingMarket is
             );
     }
 
+    /// @inheritdoc ILendingMarket
     function takeInstallmentLoanFor(
         address borrower,
         uint32 programId,

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -280,7 +280,7 @@ contract LendingMarket is
         if (addonAmount >= 0) {
             terms.addonAmount = uint256(addonAmount).toUint64();
         }
-        uint256 totalBorrowAmount = borrowAmount + terms.addonAmount;
+        uint256 principalAmount = borrowAmount + terms.addonAmount;
         uint32 blockTimestamp = _blockTimestamp().toUint32();
 
         _loans[id] = Loan.State({
@@ -292,7 +292,7 @@ contract LendingMarket is
             interestRatePrimary: terms.interestRatePrimary,
             interestRateSecondary: terms.interestRateSecondary,
             borrowAmount: borrowAmount.toUint64(),
-            trackedBalance: totalBorrowAmount.toUint64(),
+            trackedBalance: principalAmount.toUint64(),
             repaidAmount: 0,
             trackedTimestamp: blockTimestamp,
             freezeTimestamp: 0,
@@ -306,7 +306,7 @@ contract LendingMarket is
 
         IERC20(terms.token).safeTransferFrom(liquidityPool, borrower, borrowAmount);
 
-        emit LoanTaken(id, borrower, totalBorrowAmount, terms.durationInPeriods);
+        emit LoanTaken(id, borrower, principalAmount, terms.durationInPeriods);
 
         return id;
     }

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -598,10 +598,10 @@ contract LendingMarket is
         _checkLoanType(loan, uint256(Loan.Type.Installment));
 
         loanId = loan.firstInstallmentId;
-        uint256 endLoanId = loanId + loan.instalmentCount;
+        uint256 lastLoanId = loanId + loan.instalmentCount - 1;
         uint256 ongoingSubLoanCount = 0;
 
-        for(; loanId < endLoanId; ++loanId) {
+        for(; loanId <= lastLoanId; ++loanId) {
             loan = _loans[loanId];
             if (!_isRepaid(loan)) {
                 ++ongoingSubLoanCount;
@@ -727,16 +727,16 @@ contract LendingMarket is
         Loan.State storage loan = _loans[loanId];
         Loan.InstallmentLoanPreview memory preview;
         preview.instalmentCount = loan.instalmentCount;
-        uint256 endInstallmentId = loanId;
+        uint256 lastInstallmentId = loanId;
         if (preview.instalmentCount > 0) {
             loanId = loan.firstInstallmentId;
             preview.firstInstallmentId = loanId;
-            endInstallmentId = loanId + preview.instalmentCount;
+            lastInstallmentId = loanId + preview.instalmentCount - 1;
         } else {
             preview.firstInstallmentId = loanId;
         }
 
-        for (; loanId < endInstallmentId; ++loanId) {
+        for (; loanId <= lastInstallmentId; ++loanId) {
             Loan.Preview memory singleLoanPreview = _getLoanPreview(loanId, timestamp);
             preview.periodIndex = singleLoanPreview.periodIndex;
             preview.totalTrackedBalance += singleLoanPreview.trackedBalance;

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -723,16 +723,16 @@ contract LendingMarket is
         Loan.State storage loan = _loans[loanId];
         Loan.InstallmentLoanPreview memory preview;
         preview.instalmentCount = loan.instalmentCount;
-        uint256 lastInstallmentId = loanId;
+        uint256 endInstallmentId = loanId;
         if (preview.instalmentCount > 0) {
             loanId = loan.firstInstallmentId;
             preview.firstInstallmentId = loanId;
-            lastInstallmentId = loanId + preview.instalmentCount;
+            endInstallmentId = loanId + preview.instalmentCount;
         } else {
             preview.firstInstallmentId = loanId;
         }
 
-        for (; loanId <= lastInstallmentId; ++loanId) {
+        for (; loanId < endInstallmentId; ++loanId) {
             Loan.Preview memory singleLoanPreview = _getLoanPreview(loanId, timestamp);
             preview.periodIndex = singleLoanPreview.periodIndex;
             preview.totalTrackedBalance += singleLoanPreview.trackedBalance;

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -223,7 +223,7 @@ contract LendingMarket is
                 int256(addonAmounts[i]),
                 durationInPeriods[i]
             );
-            if (loanId == 0) {
+            if (i == 0) {
                 firstInstallmentId = loanId;
             }
             _updateLoanInstallmentData(loanId, firstInstallmentId, installmentCount);
@@ -854,6 +854,7 @@ contract LendingMarket is
             if (duration < previousDuration) {
                 revert DurationArrayInvalid();
             }
+            previousDuration = duration;
         }
     }
 

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -940,15 +940,21 @@ contract LendingMarket is
 
     /// @dev Checks if the loan type is correct.
     /// @param loan The storage state of the loan.
-    /// @param loanType The type of the loan according to the `Loan.Type` enum.
-    function _checkLoanType(Loan.State storage loan, uint256 loanType) internal view {
+    /// @param expectedLoanType The expected type of the loan according to the `Loan.Type` enum.
+    function _checkLoanType(Loan.State storage loan, uint256 expectedLoanType) internal view {
         if (loan.instalmentCount == 0) {
-            if (loanType != uint256(Loan.Type.Common)) {
-                revert LoanTypeUnexpected(Loan.Type(loanType), Loan.Type.Common);
+            if (expectedLoanType != uint256(Loan.Type.Common)) {
+                revert LoanTypeUnexpected(
+                    Loan.Type.Common, // actual
+                    Loan.Type.Installment // expected
+                );
             }
         } else {
-            if (loanType != uint256(Loan.Type.Installment)) {
-                revert LoanTypeUnexpected(Loan.Type(loanType), Loan.Type.Installment);
+            if (expectedLoanType != uint256(Loan.Type.Installment)) {
+                revert LoanTypeUnexpected(
+                    Loan.Type.Installment, // actual
+                    Loan.Type.Common // expected
+                );
             }
         }
     }

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -650,12 +650,41 @@ contract LendingMarket is
     }
 
     /// @inheritdoc ILendingMarket
+    function getLoanStateBatch(uint256[] calldata loanIds) external view returns (Loan.State[] memory) {
+        uint256 len = loanIds.length;
+        Loan.State[] memory states = new Loan.State[](len);
+        for (uint256 i = 0; i < len; ++i) {
+            states[i] = _loans[loanIds[i]];
+        }
+
+        return states;
+    }
+
+    /// @inheritdoc ILendingMarket
     function getLoanPreview(uint256 loanId, uint256 timestamp) external view returns (Loan.Preview memory) {
         if (timestamp == 0) {
             timestamp = _blockTimestamp();
         }
 
         return _getLoanPreview(loanId, timestamp);
+    }
+
+    /// @inheritdoc ILendingMarket
+    function getLoanPreviewBatch(
+        uint256[] calldata loanIds,
+        uint256 timestamp
+    ) external view returns (Loan.Preview[] memory) {
+        if (timestamp == 0) {
+            timestamp = _blockTimestamp();
+        }
+
+        uint256 len = loanIds.length;
+        Loan.Preview[] memory previews = new Loan.Preview[](len);
+        for (uint256 i = 0; i < len; ++i) {
+            previews[i] = _getLoanPreview(loanIds[i], timestamp);
+        }
+
+        return previews;
     }
 
     /// @inheritdoc ILendingMarket

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -597,17 +597,18 @@ contract LendingMarket is
 
         loanId = loan.firstInstallmentId;
         uint256 endLoanId = loanId + loan.instalmentCount;
-        uint256 revokedSubLoanCount = 0;
+        uint256 ongoingSubLoanCount = 0;
 
         for(; loanId < endLoanId; ++loanId) {
             loan = _loans[loanId];
             if (!_isRepaid(loan)) {
-                _revokeLoan(loanId, loan);
-                ++revokedSubLoanCount;
+                ++ongoingSubLoanCount;
             }
+            _revokeLoan(loanId, loan);
         }
 
-        if (revokedSubLoanCount == 0) {
+        // If all the sub-loans are repaid the revocation is prohibited
+        if (ongoingSubLoanCount == 0) {
             revert LoanAlreadyRepaid();
         }
 

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -173,7 +173,7 @@ contract LendingMarket is
         uint256 addonAmount,
         uint256 durationInPeriods
     ) external whenNotPaused returns (uint256) {
-        if (!_isLenderOrAlias(programId, msg.sender)) {
+        if (!isProgramLenderOrAlias(programId, msg.sender)) {
             revert Error.Unauthorized();
         }
         if (borrower == address(0)) {
@@ -624,7 +624,13 @@ contract LendingMarket is
 
     /// @inheritdoc ILendingMarket
     function isLenderOrAlias(uint256 loanId, address account) public view returns (bool) {
-        return _isLenderOrAlias(_loans[loanId].programId, account);
+        return isProgramLenderOrAlias(_loans[loanId].programId, account);
+    }
+
+    /// @inheritdoc ILendingMarket
+    function isProgramLenderOrAlias(uint32 programId, address account) public view returns (bool) {
+        address lender = _programLenders[programId];
+        return account == lender || _hasAlias[lender][account];
     }
 
     /// @inheritdoc ILendingMarket
@@ -691,14 +697,6 @@ contract LendingMarket is
     // -------------------------------------------- //
     //  Internal functions                          //
     // -------------------------------------------- //
-
-    /// @dev Checks if the provided account is a lender or an alias for a lender of a given lending program.
-    /// @param programId The identifier of the program to check.
-    /// @param account The address to check whether it's a lender or an alias.
-    function _isLenderOrAlias(uint32 programId, address account) public view returns (bool) {
-        address lender = _programLenders[programId];
-        return account == lender || _hasAlias[lender][account];
-    }
 
     /// @dev Calculates the outstanding balance of a loan.
     /// @param loan The loan to calculate the outstanding balance for.

--- a/contracts/common/Versionable.sol
+++ b/contracts/common/Versionable.sol
@@ -16,6 +16,6 @@ abstract contract Versionable is IVersionable {
      * @inheritdoc IVersionable
      */
     function $__VERSION() external pure returns (Version memory) {
-        return Version(1, 3, 0);
+        return Version(1, 4, 0);
     }
 }

--- a/contracts/common/interfaces/ICreditLineConfigurable.sol
+++ b/contracts/common/interfaces/ICreditLineConfigurable.sol
@@ -67,10 +67,10 @@ interface ICreditLineConfigurable is ICreditLine {
     ///
     /// Fields:
     ///
-    /// activeLoanCount -- the number of active loans currently held by the borrower.
-    /// closedLoanCount -- the number of loans that have been closed, with or without a full repayment.
-    /// totalActiveLoanAmount -- the total amount borrowed across all active loans.
-    /// totalClosedLoanAmount -- the total amount that was borrowed across all closed loans.
+    /// - activeLoanCount -------- the number of active loans currently held by the borrower.
+    /// - closedLoanCount -------- the number of loans that have been closed, with or without a full repayment.
+    /// - totalActiveLoanAmount -- the total amount borrowed across all active loans.
+    /// - totalClosedLoanAmount -- the total amount that was borrowed across all closed loans.
     struct BorrowerState {
         // Slot 1
         uint16 activeLoanCount;

--- a/contracts/common/interfaces/core/ILendingMarket.sol
+++ b/contracts/common/interfaces/core/ILendingMarket.sol
@@ -263,6 +263,11 @@ interface ILendingMarket {
     /// @param account The address to check whether it's a lender or an alias.
     function isLenderOrAlias(uint256 loanId, address account) external view returns (bool);
 
+    /// @dev Checks if the provided account is a lender or an alias for a lender of a given lending program.
+    /// @param programId The identifier of the program to check.
+    /// @param account The address to check whether it's a lender or an alias.
+    function isProgramLenderOrAlias(uint32 programId, address account) external view returns (bool);
+
     /// @dev Checks if the provided account is an alias for a lender.
     /// @param lender The address of the lender to check alias for.
     /// @param account The address to check whether it's an alias or not.

--- a/contracts/common/interfaces/core/ILendingMarket.sol
+++ b/contracts/common/interfaces/core/ILendingMarket.sol
@@ -41,7 +41,7 @@ interface ILendingMarket {
     );
 
     /// @dev Emitted when an installment loan is taken in the form of multiple sub-loans.
-    /// @param firstInstallmentId The ID of the first installment.
+    /// @param firstInstallmentId The ID of the first sub-loan of the installment loan.
     /// @param borrower The address of the borrower.
     /// @param programId The ID of the lending program.
     /// @param installmentCount The total number of installments.
@@ -81,6 +81,14 @@ interface ILendingMarket {
     /// @dev Emitted when a loan is revoked.
     /// @param loanId The unique identifier of the loan.
     event LoanRevoked(uint256 indexed loanId);
+
+    /// @dev Emitted when an installment loan is revoked.
+    /// @param firstInstallmentId The ID of the first sub-loan of the installment loan.
+    /// @param installmentCount The total number of installments.
+    event InstallmentLoanRevoked(
+        uint256 indexed firstInstallmentId,
+        uint256 installmentCount
+    );
 
     /// @dev Emitted when the duration of the loan is updated.
     /// @param loanId The unique identifier of the loan.
@@ -246,9 +254,13 @@ interface ILendingMarket {
     //  Borrower OR Lender functions                //
     // -------------------------------------------- //
 
-    /// @dev Revokes a loan.
+    /// @dev Revokes a common loan.
     /// @param loanId The unique identifier of the loan to revoke.
     function revokeLoan(uint256 loanId) external;
+
+    /// @dev Revokes an installment loan.
+    /// @param loanId The unique identifier of any sub-loan of the installment loan to revoke.
+    function revokeInstallmentLoan(uint256 loanId) external;
 
     // -------------------------------------------- //
     //  View functions                              //

--- a/contracts/common/interfaces/core/ILendingMarket.sol
+++ b/contracts/common/interfaces/core/ILendingMarket.sol
@@ -168,7 +168,7 @@ interface ILendingMarket {
     //  Borrower functions                          //
     // -------------------------------------------- //
 
-    /// @dev Takes a loan.
+    /// @dev Takes a common loan.
     /// @param programId The identifier of the program to take the loan from.
     /// @param borrowAmount The desired amount of tokens to borrow.
     /// @param durationInPeriods The desired duration of the loan in periods.
@@ -179,7 +179,7 @@ interface ILendingMarket {
         uint256 durationInPeriods
     ) external returns (uint256);
 
-    /// @dev Takes a loan for a provided account. Can be called only by an account with a special role.
+    /// @dev Takes a common loan for a provided account. Can be called only by an account with a special role.
     /// @param borrower The account for whom the loan is taken.
     /// @param programId The identifier of the program to take the loan from.
     /// @param borrowAmount The desired amount of tokens to borrow.
@@ -193,6 +193,22 @@ interface ILendingMarket {
         uint256 addonAmount,
         uint256 durationInPeriods
     ) external returns (uint256);
+
+    /// @dev Takes an installment loan for a provided account. Can be called only by an account with a special role.
+    /// @param borrower The account for whom the loan is taken.
+    /// @param programId The identifier of the program to take the loan from.
+    /// @param borrowAmounts The desired amounts of tokens to borrow for each installment.
+    /// @param addonAmounts The off-chain calculated addon amounts for each installment.
+    /// @param durationInPeriods The desired duration of each installment in periods.
+    /// @return firstInstallmentId The unique identifier of the first sub-loan of the installment loan.
+    /// @return installmentCount The total number of installments.
+    function takeInstallmentLoanFor(
+        address borrower,
+        uint32 programId,
+        uint256[] calldata borrowAmounts,
+        uint256[] calldata addonAmounts,
+        uint256[] calldata durationInPeriods
+    ) external returns (uint256 firstInstallmentId, uint256 installmentCount);
 
     /// @dev Repays a loan.
     /// @param loanId The unique identifier of the loan to repay.

--- a/contracts/common/interfaces/core/ILendingMarket.sol
+++ b/contracts/common/interfaces/core/ILendingMarket.sol
@@ -89,7 +89,7 @@ interface ILendingMarket {
     /// @param firstInstallmentId The ID of the first sub-loan of the installment loan.
     /// @param installmentCount The total number of installments.
     event InstallmentLoanRevoked(
-        uint256 indexed firstInstallmentId,
+        uint256 indexed firstInstallmentId, // Tools: this comment prevents Prettier from formatting into a single line.
         uint256 installmentCount
     );
 

--- a/contracts/common/interfaces/core/ILendingMarket.sol
+++ b/contracts/common/interfaces/core/ILendingMarket.sol
@@ -34,12 +34,12 @@ interface ILendingMarket {
     /// @dev Emitted when a loan is taken.
     /// @param loanId The unique identifier of the loan.
     /// @param borrower The address of the borrower of the loan.
-    /// @param borrowAmount The initial total amount of the loan, including the addon.
+    /// @param principalAmount The initial principal amount of the loan, including the borrow amount and addon.
     /// @param durationInPeriods The duration of the loan in periods.
     event LoanTaken(
         uint256 indexed loanId, // Tools: this comment prevents Prettier from formatting into a single line.
         address indexed borrower,
-        uint256 borrowAmount,
+        uint256 principalAmount,
         uint256 durationInPeriods
     );
 

--- a/contracts/common/interfaces/core/ILendingMarket.sol
+++ b/contracts/common/interfaces/core/ILendingMarket.sol
@@ -10,7 +10,7 @@ import { Loan } from "../../libraries/Loan.sol";
 ///
 /// The lending market supports two types of loans:
 ///
-/// 1. Common Loans:
+/// 1. Ordinary Loans:
 /// - A single, standalone loan.
 /// - Represented by one loan entity on the smart-contract side with a unique ID.
 /// - Has `firstInstallmentId` and `installmentCount` set to 0 in the loan structure.
@@ -18,14 +18,14 @@ import { Loan } from "../../libraries/Loan.sol";
 /// 2. Installment Loans:
 /// - A loan split into multiple installments (sub-loans).
 /// - Each installment is a separate loan entity on the smart-contract side with its own unique ID.
-/// - All installments are represented by the same loan structure as common loans.
+/// - All installments are represented by the same loan structure as ordinary loans.
 /// - The `firstInstallmentId` field stores the ID of the first installment.
 /// - The `installmentCount` field stores the total number of installments.
 /// - Any installment ID can be used to reference the whole installment loan.
 ///
 /// Note: Throughout the code, the terms "loan" (without additional specification), "sub-loan", and "installment"
 /// are used interchangeably since they all represent the same underlying loan structure in the smart contract.
-/// Unless otherwise specified, a smart-contract function is applicable to both common loans and sub-loans.
+/// Unless otherwise specified, a smart-contract function is applicable to both ordinary loans and sub-loans.
 interface ILendingMarket {
     // -------------------------------------------- //
     //  Events                                      //
@@ -171,7 +171,7 @@ interface ILendingMarket {
     //  Borrower functions                          //
     // -------------------------------------------- //
 
-    /// @dev Takes a common loan.
+    /// @dev Takes an ordinary loan.
     /// @param programId The identifier of the program to take the loan from.
     /// @param borrowAmount The desired amount of tokens to borrow.
     /// @param durationInPeriods The desired duration of the loan in periods.
@@ -182,7 +182,7 @@ interface ILendingMarket {
         uint256 durationInPeriods
     ) external returns (uint256);
 
-    /// @dev Takes a common loan for a provided account. Can be called only by an account with a special role.
+    /// @dev Takes an ordinary loan for a provided account. Can be called only by an account with a special role.
     /// @param borrower The account for whom the loan is taken.
     /// @param programId The identifier of the program to take the loan from.
     /// @param borrowAmount The desired amount of tokens to borrow.
@@ -244,25 +244,25 @@ interface ILendingMarket {
     /// @param liquidityPool The address of the liquidity pool to associate with the program.
     function updateProgram(uint32 programId, address creditLine, address liquidityPool) external;
 
-    /// @dev Freezes a common loan or a sub-loan.
+    /// @dev Freezes an ordinary loan or a sub-loan.
     /// @param loanId The unique identifier of the loan to freeze.
     function freeze(uint256 loanId) external;
 
-    /// @dev Unfreezes a common loan or a sub-loan.
+    /// @dev Unfreezes an ordinary loan or a sub-loan.
     /// @param loanId The unique identifier of the loan to unfreeze.
     function unfreeze(uint256 loanId) external;
 
-    /// @dev Updates the duration of a common loan or a sub-loan.
+    /// @dev Updates the duration of an ordinary loan or a sub-loan.
     /// @param loanId The unique identifier of the loan whose duration is to update.
     /// @param newDurationInPeriods The new duration of the loan, specified in periods.
     function updateLoanDuration(uint256 loanId, uint256 newDurationInPeriods) external;
 
-    /// @dev Updates the primary interest rate of a common loan or a sub-loan.
+    /// @dev Updates the primary interest rate of an ordinary loan or a sub-loan.
     /// @param loanId The unique identifier of the loan whose primary interest rate is to update.
     /// @param newInterestRate The new primary interest rate of the loan.
     function updateLoanInterestRatePrimary(uint256 loanId, uint256 newInterestRate) external;
 
-    /// @dev Updates the secondary interest rate of a common loan or a sub-loan.
+    /// @dev Updates the secondary interest rate of an ordinary loan or a sub-loan.
     /// @param loanId The unique identifier of the loan whose secondary interest rate is to update.
     /// @param newInterestRate The new secondary interest rate of the loan.
     function updateLoanInterestRateSecondary(uint256 loanId, uint256 newInterestRate) external;
@@ -276,7 +276,7 @@ interface ILendingMarket {
     //  Borrower OR Lender functions                //
     // -------------------------------------------- //
 
-    /// @dev Revokes a common loan.
+    /// @dev Revokes an ordinary loan.
     /// @param loanId The unique identifier of the loan to revoke.
     function revokeLoan(uint256 loanId) external;
 
@@ -313,23 +313,23 @@ interface ILendingMarket {
     /// @return The address of the liquidity pool associated with the program.
     function getProgramLiquidityPool(uint32 programId) external view returns (address);
 
-    /// @dev Gets the stored state of a given common loan or a sub-loan.
+    /// @dev Gets the stored state of a given ordinary loan or a sub-loan.
     /// @param loanId The unique identifier of the loan to check.
     /// @return The stored state of the loan (see the `Loan.State` struct).
     function getLoanState(uint256 loanId) external view returns (Loan.State memory);
 
-    /// @dev Gets the stored state of a batch of common loans or sub-loans.
+    /// @dev Gets the stored state of a batch of ordinary loans or sub-loans.
     /// @param loanIds The unique identifiers of the loans to check.
     /// @return The stored states of the loans (see the `Loan.State` struct).
     function getLoanStateBatch(uint256[] calldata loanIds) external view returns (Loan.State[] memory);
 
-    /// @dev Gets the preview of a common loan or a sub-loan at a specific timestamp.
+    /// @dev Gets the preview of an ordinary loan or a sub-loan at a specific timestamp.
     /// @param loanId The unique identifier of the loan to check.
     /// @param timestamp The timestamp to get the loan preview for.
     /// @return The preview state of the loan (see the `Loan.Preview` struct).
     function getLoanPreview(uint256 loanId, uint256 timestamp) external view returns (Loan.Preview memory);
 
-    /// @dev Gets the loan preview at a specific timestamp for a batch of common loans or sub-loans.
+    /// @dev Gets the loan preview at a specific timestamp for a batch of ordinary loans or sub-loans.
     /// @param loanIds The unique identifiers of the loans to check.
     /// @param timestamp The timestamp to get the loan preview for. If 0, the current timestamp is used.
     /// @return The preview states of the loans (see the `Loan.Preview` struct).
@@ -340,7 +340,7 @@ interface ILendingMarket {
 
     /// @dev Gets the preview of an installment loan at a specific timestamp.
     ///
-    /// This function can be called for a common loan as well. In this case, it returns the preview of the common loan.
+    /// This function can be called for an ordinary loan as well, but the resulting data will be slightly different.
     /// See additional comments for the the `Loan.InstallmentLoanPreview` structure
     ///
     /// @param loanId The unique identifier of any sub-loan of the installment loan to check.
@@ -351,7 +351,7 @@ interface ILendingMarket {
         uint256 timestamp
     ) external view returns (Loan.InstallmentLoanPreview memory);
 
-    /// @dev Checks if the provided account is a lender or an alias for a lender of a given common loan or a sub-loan.
+    /// @dev Checks if the provided account is a lender or an alias for a lender of a given ordinary loan or a sub-loan.
     /// @param loanId The unique identifier of the loan to check.
     /// @param account The address to check whether it's a lender or an alias.
     function isLenderOrAlias(uint256 loanId, address account) external view returns (bool);

--- a/contracts/common/interfaces/core/ILendingMarket.sol
+++ b/contracts/common/interfaces/core/ILendingMarket.sol
@@ -199,7 +199,7 @@ interface ILendingMarket {
     /// @param programId The identifier of the program to take the loan from.
     /// @param borrowAmounts The desired amounts of tokens to borrow for each installment.
     /// @param addonAmounts The off-chain calculated addon amounts for each installment.
-    /// @param durationInPeriods The desired duration of each installment in periods.
+    /// @param durationsInPeriods The desired duration of each installment in periods.
     /// @return firstInstallmentId The unique identifier of the first sub-loan of the installment loan.
     /// @return installmentCount The total number of installments.
     function takeInstallmentLoanFor(
@@ -207,7 +207,7 @@ interface ILendingMarket {
         uint32 programId,
         uint256[] calldata borrowAmounts,
         uint256[] calldata addonAmounts,
-        uint256[] calldata durationInPeriods
+        uint256[] calldata durationsInPeriods
     ) external returns (uint256 firstInstallmentId, uint256 installmentCount);
 
     /// @dev Repays a loan.

--- a/contracts/common/interfaces/core/ILendingMarket.sol
+++ b/contracts/common/interfaces/core/ILendingMarket.sol
@@ -262,11 +262,20 @@ interface ILendingMarket {
     /// @return The stored state of the loan (see the Loan.State struct).
     function getLoanState(uint256 loanId) external view returns (Loan.State memory);
 
+    /// @dev TODO
+    function getLoanStateBatch(uint256[] calldata loanIds) external view returns (Loan.State[] memory);
+
     /// @dev Gets the loan preview at a specific timestamp.
     /// @param loanId The unique identifier of the loan to check.
     /// @param timestamp The timestamp to get the loan preview for.
     /// @return The preview state of the loan (see the Loan.Preview struct).
     function getLoanPreview(uint256 loanId, uint256 timestamp) external view returns (Loan.Preview memory);
+
+    /// @dev TODO
+    function getLoanPreviewBatch(
+        uint256[] calldata loanIds,
+        uint256 timestamp
+    ) external view returns (Loan.Preview[] memory);
 
     /// @dev TODO
     function getInstallmentLoanPreview(

--- a/contracts/common/interfaces/core/ILendingMarket.sol
+++ b/contracts/common/interfaces/core/ILendingMarket.sol
@@ -8,21 +8,24 @@ import { Loan } from "../../libraries/Loan.sol";
 /// @author CloudWalk Inc. (See https://cloudwalk.io)
 /// @dev Defines the lending market contract functions and events.
 ///
-/// There can be two types of loans:
-/// - Common loans: a single loan that is taken by a borrower.
-/// - Installment loans: a loan that is taken by a borrower in the form of multiple sub-loans.
+/// The lending market supports two types of loans:
 ///
-/// Common loans are represented by a single loan with a unique ID.
+/// 1. Common Loans:
+/// - A single, standalone loan.
+/// - Represented by one loan entity on the smart-contract side with a unique ID.
+/// - Has `firstInstallmentId` and `installmentCount` set to 0 in the loan structure.
 ///
-/// Installment loans are represented by multiple sub-loans with unique IDs.
-/// The ID of any sub-loan can be used as the ID of the installment loan.
+/// 2. Installment Loans:
+/// - A loan split into multiple installments (sub-loans).
+/// - Each installment is a separate loan entity on the smart-contract side with its own unique ID.
+/// - All installments are represented by the same loan structure as common loans.
+/// - The `firstInstallmentId` field stores the ID of the first installment.
+/// - The `installmentCount` field stores the total number of installments.
+/// - Any installment ID can be used to reference the whole installment loan.
 ///
-/// There is no difference in the logic and storage of the common loans and sub-loans of an installment loan.
-/// The names are introduced only for clarity and to distinguish between the two types of loans.
-/// If no additional information is provided, the term "loan" refers to a common loan as well as a sub-loan.
-///
-/// The ID of the first sub-loan and the total number of sub-loans of an installment loan is stored in the `firstInstallmentId`
-/// and `instalmentCount` fields of the loan structure. For common loans, these fields are set to 0.
+/// Note: Throughout the code, the terms "loan" (without additional specification), "sub-loan", and "installment"
+/// are used interchangeably since they all represent the same underlying loan
+/// structure in the smart contract.
 interface ILendingMarket {
     // -------------------------------------------- //
     //  Events                                      //

--- a/contracts/common/interfaces/core/ILendingMarket.sol
+++ b/contracts/common/interfaces/core/ILendingMarket.sol
@@ -24,6 +24,16 @@ interface ILendingMarket {
         uint256 durationInPeriods
     );
 
+    /// @dev TODO
+    event InstallmentLoanTaken(
+        uint256 indexed firstInstallmentId,
+        address indexed borrower,
+        uint256 indexed programId,
+        uint256 installmentCount,
+        uint256 totalBorrowAmount,
+        uint256 totalAddonAmount
+    );
+
     /// @dev Emitted when a loan is repaid (fully or partially).
     /// @param loanId The unique identifier of the loan.
     /// @param repayer The address of the repayer (borrower or third-party).
@@ -257,6 +267,12 @@ interface ILendingMarket {
     /// @param timestamp The timestamp to get the loan preview for.
     /// @return The preview state of the loan (see the Loan.Preview struct).
     function getLoanPreview(uint256 loanId, uint256 timestamp) external view returns (Loan.Preview memory);
+
+    /// @dev TODO
+    function getInstallmentLoanPreview(
+        uint256 loanId,
+        uint256 timestamp
+    ) external view returns (Loan.InstallmentLoanPreview memory);
 
     /// @dev Checks if the provided account is a lender or an alias for a lender of a given loan.
     /// @param loanId The unique identifier of the loan to check.

--- a/contracts/common/interfaces/core/ILendingMarket.sol
+++ b/contracts/common/interfaces/core/ILendingMarket.sol
@@ -24,8 +24,8 @@ import { Loan } from "../../libraries/Loan.sol";
 /// - Any installment ID can be used to reference the whole installment loan.
 ///
 /// Note: Throughout the code, the terms "loan" (without additional specification), "sub-loan", and "installment"
-/// are used interchangeably since they all represent the same underlying loan
-/// structure in the smart contract.
+/// are used interchangeably since they all represent the same underlying loan structure in the smart contract.
+/// Unless otherwise specified, a smart-contract function is applicable to both common loans and sub-loans.
 interface ILendingMarket {
     // -------------------------------------------- //
     //  Events                                      //
@@ -197,7 +197,10 @@ interface ILendingMarket {
         uint256 durationInPeriods
     ) external returns (uint256);
 
-    /// @dev Takes an installment loan for a provided account. Can be called only by an account with a special role.
+    /// @dev Takes an installment loan with multiple sub-loans for a provided account.
+    ///
+    /// Can be called only by an account with a special role.
+    ///
     /// @param borrower The account for whom the loan is taken.
     /// @param programId The identifier of the program to take the loan from.
     /// @param borrowAmounts The desired amounts of tokens to borrow for each installment.
@@ -241,25 +244,25 @@ interface ILendingMarket {
     /// @param liquidityPool The address of the liquidity pool to associate with the program.
     function updateProgram(uint32 programId, address creditLine, address liquidityPool) external;
 
-    /// @dev Freezes a loan.
+    /// @dev Freezes a common loan or a sub-loan.
     /// @param loanId The unique identifier of the loan to freeze.
     function freeze(uint256 loanId) external;
 
-    /// @dev Unfreezes a loan.
+    /// @dev Unfreezes a common loan or a sub-loan.
     /// @param loanId The unique identifier of the loan to unfreeze.
     function unfreeze(uint256 loanId) external;
 
-    /// @dev Updates the duration of a loan.
+    /// @dev Updates the duration of a common loan or a sub-loan.
     /// @param loanId The unique identifier of the loan whose duration is to update.
     /// @param newDurationInPeriods The new duration of the loan, specified in periods.
     function updateLoanDuration(uint256 loanId, uint256 newDurationInPeriods) external;
 
-    /// @dev Updates the primary interest rate of a loan.
+    /// @dev Updates the primary interest rate of a common loan or a sub-loan.
     /// @param loanId The unique identifier of the loan whose primary interest rate is to update.
     /// @param newInterestRate The new primary interest rate of the loan.
     function updateLoanInterestRatePrimary(uint256 loanId, uint256 newInterestRate) external;
 
-    /// @dev Updates the secondary interest rate of a loan.
+    /// @dev Updates the secondary interest rate of a common loan or a sub-loan.
     /// @param loanId The unique identifier of the loan whose secondary interest rate is to update.
     /// @param newInterestRate The new secondary interest rate of the loan.
     function updateLoanInterestRateSecondary(uint256 loanId, uint256 newInterestRate) external;
@@ -277,7 +280,7 @@ interface ILendingMarket {
     /// @param loanId The unique identifier of the loan to revoke.
     function revokeLoan(uint256 loanId) external;
 
-    /// @dev Revokes an installment loan.
+    /// @dev Revokes an installment loan by revoking all of its sub-loans.
     /// @param loanId The unique identifier of any sub-loan of the installment loan to revoke.
     function revokeInstallmentLoan(uint256 loanId) external;
 
@@ -310,23 +313,23 @@ interface ILendingMarket {
     /// @return The address of the liquidity pool associated with the program.
     function getProgramLiquidityPool(uint32 programId) external view returns (address);
 
-    /// @dev Gets the stored state of a given loan.
+    /// @dev Gets the stored state of a given common loan or a sub-loan.
     /// @param loanId The unique identifier of the loan to check.
     /// @return The stored state of the loan (see the `Loan.State` struct).
     function getLoanState(uint256 loanId) external view returns (Loan.State memory);
 
-    /// @dev Gets the stored state of a batch of loans.
+    /// @dev Gets the stored state of a batch of common loans or sub-loans.
     /// @param loanIds The unique identifiers of the loans to check.
     /// @return The stored states of the loans (see the `Loan.State` struct).
     function getLoanStateBatch(uint256[] calldata loanIds) external view returns (Loan.State[] memory);
 
-    /// @dev Gets the loan preview at a specific timestamp.
+    /// @dev Gets the preview of a common loan or a sub-loan at a specific timestamp.
     /// @param loanId The unique identifier of the loan to check.
     /// @param timestamp The timestamp to get the loan preview for.
     /// @return The preview state of the loan (see the `Loan.Preview` struct).
     function getLoanPreview(uint256 loanId, uint256 timestamp) external view returns (Loan.Preview memory);
 
-    /// @dev Gets the loan preview at a specific timestamp for a batch of loans.
+    /// @dev Gets the loan preview at a specific timestamp for a batch of common loans or sub-loans.
     /// @param loanIds The unique identifiers of the loans to check.
     /// @param timestamp The timestamp to get the loan preview for. If 0, the current timestamp is used.
     /// @return The preview states of the loans (see the `Loan.Preview` struct).
@@ -335,16 +338,20 @@ interface ILendingMarket {
         uint256 timestamp
     ) external view returns (Loan.Preview[] memory);
 
-    /// @dev Gets the installment loan preview at a specific timestamp.
+    /// @dev Gets the preview of an installment loan at a specific timestamp.
+    ///
+    /// This function can be called for a common loan as well. In this case, it returns the preview of the common loan.
+    /// See additional comments for the the `Loan.InstallmentLoanPreview` structure
+    ///
     /// @param loanId The unique identifier of any sub-loan of the installment loan to check.
     /// @param timestamp The timestamp to get the installment loan preview for. If 0, the current timestamp is used.
-    /// @return The preview state of the installment loan (see the `Loan.InstallmentLoanPreview` struct).
+    /// @return The preview state of the installment loan (see the `Loan.InstallmentLoanPreview` structure).
     function getInstallmentLoanPreview(
         uint256 loanId,
         uint256 timestamp
     ) external view returns (Loan.InstallmentLoanPreview memory);
 
-    /// @dev Checks if the provided account is a lender or an alias for a lender of a given loan.
+    /// @dev Checks if the provided account is a lender or an alias for a lender of a given common loan or a sub-loan.
     /// @param loanId The unique identifier of the loan to check.
     /// @param account The address to check whether it's a lender or an alias.
     function isLenderOrAlias(uint256 loanId, address account) external view returns (bool);

--- a/contracts/common/interfaces/core/ILendingMarket.sol
+++ b/contracts/common/interfaces/core/ILendingMarket.sol
@@ -7,6 +7,22 @@ import { Loan } from "../../libraries/Loan.sol";
 /// @title ILendingMarket interface
 /// @author CloudWalk Inc. (See https://cloudwalk.io)
 /// @dev Defines the lending market contract functions and events.
+///
+/// There can be two types of loans:
+/// - Common loans: a single loan that is taken by a borrower.
+/// - Installment loans: a loan that is taken by a borrower in the form of multiple sub-loans.
+///
+/// Common loans are represented by a single loan with a unique ID.
+///
+/// Installment loans are represented by multiple sub-loans with unique IDs.
+/// The ID of any sub-loan can be used as the ID of the installment loan.
+///
+/// There is no difference in the logic and storage of the common loans and sub-loans of an installment loan.
+/// The names are introduced only for clarity and to distinguish between the two types of loans.
+/// If no additional information is provided, the term "loan" refers to a common loan as well as a sub-loan.
+///
+/// The ID of the first sub-loan and the total number of sub-loans of an installment loan is stored in the `firstInstallmentId`
+/// and `instalmentCount` fields of the loan structure. For common loans, these fields are set to 0.
 interface ILendingMarket {
     // -------------------------------------------- //
     //  Events                                      //
@@ -24,7 +40,13 @@ interface ILendingMarket {
         uint256 durationInPeriods
     );
 
-    /// @dev TODO
+    /// @dev Emitted when an installment loan is taken in the form of multiple sub-loans.
+    /// @param firstInstallmentId The ID of the first installment.
+    /// @param borrower The address of the borrower.
+    /// @param programId The ID of the lending program.
+    /// @param installmentCount The total number of installments.
+    /// @param totalBorrowAmount The total amount borrowed.
+    /// @param totalAddonAmount The total addon amount of the loan.
     event InstallmentLoanTaken(
         uint256 indexed firstInstallmentId,
         address indexed borrower,
@@ -259,25 +281,33 @@ interface ILendingMarket {
 
     /// @dev Gets the stored state of a given loan.
     /// @param loanId The unique identifier of the loan to check.
-    /// @return The stored state of the loan (see the Loan.State struct).
+    /// @return The stored state of the loan (see the `Loan.State` struct).
     function getLoanState(uint256 loanId) external view returns (Loan.State memory);
 
-    /// @dev TODO
+    /// @dev Gets the stored state of a batch of loans.
+    /// @param loanIds The unique identifiers of the loans to check.
+    /// @return The stored states of the loans (see the `Loan.State` struct).
     function getLoanStateBatch(uint256[] calldata loanIds) external view returns (Loan.State[] memory);
 
     /// @dev Gets the loan preview at a specific timestamp.
     /// @param loanId The unique identifier of the loan to check.
     /// @param timestamp The timestamp to get the loan preview for.
-    /// @return The preview state of the loan (see the Loan.Preview struct).
+    /// @return The preview state of the loan (see the `Loan.Preview` struct).
     function getLoanPreview(uint256 loanId, uint256 timestamp) external view returns (Loan.Preview memory);
 
-    /// @dev TODO
+    /// @dev Gets the loan preview at a specific timestamp for a batch of loans.
+    /// @param loanIds The unique identifiers of the loans to check.
+    /// @param timestamp The timestamp to get the loan preview for. If 0, the current timestamp is used.
+    /// @return The preview states of the loans (see the `Loan.Preview` struct).
     function getLoanPreviewBatch(
         uint256[] calldata loanIds,
         uint256 timestamp
     ) external view returns (Loan.Preview[] memory);
 
-    /// @dev TODO
+    /// @dev Gets the installment loan preview at a specific timestamp.
+    /// @param loanId The unique identifier of any sub-loan of the installment loan to check.
+    /// @param timestamp The timestamp to get the installment loan preview for. If 0, the current timestamp is used.
+    /// @return The preview state of the installment loan (see the `Loan.InstallmentLoanPreview` struct).
     function getInstallmentLoanPreview(
         uint256 loanId,
         uint256 timestamp

--- a/contracts/common/libraries/Constants.sol
+++ b/contracts/common/libraries/Constants.sol
@@ -22,5 +22,5 @@ library Constants {
     uint64 internal constant ACCURACY_FACTOR = 10000;
 
     /// @dev The maximum number of installments. Must not be greater than uint16
-    uint256 internal constant INSTALLMENT_COUNT_MAX = 256;
+    uint256 internal constant INSTALLMENT_COUNT_MAX = 255;
 }

--- a/contracts/common/libraries/Constants.sol
+++ b/contracts/common/libraries/Constants.sol
@@ -20,4 +20,7 @@ library Constants {
 
     /// @dev The accuracy factor used for loan amounts calculation.
     uint64 internal constant ACCURACY_FACTOR = 10000;
+
+    /// @dev The maximum number of installments. Must not be greater than uint16
+    uint256 internal constant INSTALLMENT_COUNT_MAX = 256;
 }

--- a/contracts/common/libraries/Loan.sol
+++ b/contracts/common/libraries/Loan.sol
@@ -6,6 +6,16 @@ pragma solidity 0.8.24;
 /// @author CloudWalk Inc. (See https://cloudwalk.io)
 /// @dev Defines the common types used for loan management.
 library Loan {
+    /// @dev The type of a loan.
+    ///
+    /// Possible values:
+    /// - Common = 0 ------- A common loan.
+    /// - Installment = 1 -- An installment loan.
+    enum Type {
+        Common,
+        Installment
+    }
+
     /// @dev A struct that defines the stored state of a loan.
     struct State {
         // Slot1

--- a/contracts/common/libraries/Loan.sol
+++ b/contracts/common/libraries/Loan.sol
@@ -62,11 +62,35 @@ library Loan {
     }
 
     /// @dev A struct that defines the preview of an installment loan.
+    ///
+    /// The structure can be returned for both common and installment loans.
+    ///
+    /// The purpose of the fields in the case of installment loans:
+    ///
+    /// - firstInstallmentId ------- The first installment ID.
+    /// - instalmentCount ---------- The total number of installments.
+    /// - periodIndex -------------- The period index that matches the preview timestamp.
+    /// - totalTrackedBalance ------ The total tracked balance of all installments.
+    /// - totalOutstandingBalance -- The total outstanding balance of all installments.
+    ///
+    /// The purpose of the fields in the case of common loans:
+    ///
+    /// - firstInstallmentId ------- The ID of the loan.
+    /// - instalmentCount ---------- The total number of installments that always equals zero.
+    /// - periodIndex -------------- The period index that matches the preview timestamp.
+    /// - totalTrackedBalance ------ The tracked balance of the loan.
+    /// - totalOutstandingBalance -- The outstanding balance of the loan.
+    ///
+    /// Notes:
+    ///
+    /// 1. The `totalTrackedBalance` fields calculates as the sum of tracked balances of all installments.
+    /// 2. The `totalOutstandingBalance` fields calculates as the sum of rounded tracked balances
+    ///    of all installments according to the `ACCURACY_FACTOR` constant.
     struct InstallmentLoanPreview {
-        uint256 firstInstallmentId;      // The ID of the first installment of the installment loan.
-        uint256 instalmentCount;         // The total number of installments of the installment loan.
-        uint256 periodIndex;             // The period index that matches the preview timestamp.
-        uint256 totalTrackedBalance;     // The total tracked balance of all sub-loans of the installment loan.
-        uint256 totalOutstandingBalance; // The total outstanding balance of all sub-loans of the installment loan.
+        uint256 firstInstallmentId;      
+        uint256 instalmentCount;
+        uint256 periodIndex;
+        uint256 totalTrackedBalance;
+        uint256 totalOutstandingBalance;
     }
 }

--- a/contracts/common/libraries/Loan.sol
+++ b/contracts/common/libraries/Loan.sol
@@ -28,8 +28,8 @@ library Loan {
         uint64 trackedBalance;        // The borrow balance of the loan that is tracked over its lifetime.
         uint32 trackedTimestamp;      // The timestamp when the loan was last paid or its balance was updated.
         uint32 freezeTimestamp;       // The timestamp when the loan was frozen. Zero value for unfrozen loans.
-        uint40 firstInstallmentId;    // TODO
-        uint16 instalmentCount;       // TODO
+        uint40 firstInstallmentId;    // The ID of the first installment for sub-loans or zero for common loans.
+        uint16 instalmentCount;       // The total number of installments for sub-loans or zero for common loans.
         // uint8 __reserved;          // Reserved for future use.
     }
 
@@ -51,12 +51,12 @@ library Loan {
         uint256 outstandingBalance; // The outstanding balance of the loan at the previewed period.
     }
 
-    /// @dev TODO
+    /// @dev A struct that defines the preview of an installment loan.
     struct InstallmentLoanPreview {
-        uint256 firstInstallmentId;
-        uint256 instalmentCount;
-        uint256 periodIndex;
-        uint256 totalTrackedBalance;
-        uint256 totalOutstandingBalance;
+        uint256 firstInstallmentId;      // The ID of the first installment of the installment loan.
+        uint256 instalmentCount;         // The total number of installments of the installment loan.
+        uint256 periodIndex;             // The period index that matches the preview timestamp.
+        uint256 totalTrackedBalance;     // The total tracked balance of all sub-loans of the installment loan.
+        uint256 totalOutstandingBalance; // The total outstanding balance of all sub-loans of the installment loan.
     }
 }

--- a/contracts/common/libraries/Loan.sol
+++ b/contracts/common/libraries/Loan.sol
@@ -10,7 +10,7 @@ library Loan {
     ///
     /// Possible values:
     /// - Common = 0 ------- A common loan.
-    /// - Installment = 1 -- An installment loan.
+    /// - Installment = 1 -- A sub-loan of an installment loan.
     enum Type {
         Common,
         Installment

--- a/contracts/common/libraries/Loan.sol
+++ b/contracts/common/libraries/Loan.sol
@@ -9,10 +9,10 @@ library Loan {
     /// @dev The type of a loan.
     ///
     /// Possible values:
-    /// - Common = 0 ------- A common loan.
+    /// - Ordinary = 0 ----- An ordinary loan.
     /// - Installment = 1 -- A sub-loan of an installment loan.
     enum Type {
-        Common,
+        Ordinary,
         Installment
     }
 
@@ -38,8 +38,8 @@ library Loan {
         uint64 trackedBalance;        // The borrow balance of the loan that is tracked over its lifetime.
         uint32 trackedTimestamp;      // The timestamp when the loan was last paid or its balance was updated.
         uint32 freezeTimestamp;       // The timestamp when the loan was frozen. Zero value for unfrozen loans.
-        uint40 firstInstallmentId;    // The ID of the first installment for sub-loans or zero for common loans.
-        uint16 instalmentCount;       // The total number of installments for sub-loans or zero for common loans.
+        uint40 firstInstallmentId;    // The ID of the first installment for sub-loans or zero for ordinary loans.
+        uint16 instalmentCount;       // The total number of installments for sub-loans or zero for ordinary loans.
         // uint8 __reserved;          // Reserved for future use.
     }
 
@@ -63,7 +63,7 @@ library Loan {
 
     /// @dev A struct that defines the preview of an installment loan.
     ///
-    /// The structure can be returned for both common and installment loans.
+    /// The structure can be returned for both ordinary and installment loans.
     ///
     /// The purpose of the fields in the case of installment loans:
     ///
@@ -73,7 +73,7 @@ library Loan {
     /// - totalTrackedBalance ------ The total tracked balance of all installments.
     /// - totalOutstandingBalance -- The total outstanding balance of all installments.
     ///
-    /// The purpose of the fields in the case of common loans:
+    /// The purpose of the fields in the case of ordinary loans:
     ///
     /// - firstInstallmentId ------- The ID of the loan.
     /// - instalmentCount ---------- The total number of installments that always equals zero.

--- a/contracts/common/libraries/Loan.sol
+++ b/contracts/common/libraries/Loan.sol
@@ -28,6 +28,9 @@ library Loan {
         uint64 trackedBalance;        // The borrow balance of the loan that is tracked over its lifetime.
         uint32 trackedTimestamp;      // The timestamp when the loan was last paid or its balance was updated.
         uint32 freezeTimestamp;       // The timestamp when the loan was frozen. Zero value for unfrozen loans.
+        uint40 firstInstallmentId;    // TODO
+        uint16 instalmentCount;       // TODO
+        // uint8 __reserved;          // Reserved for future use.
     }
 
     /// @dev A struct that defines the terms of the loan.
@@ -46,5 +49,14 @@ library Loan {
         uint256 periodIndex;        // The period index that matches the preview timestamp.
         uint256 trackedBalance;     // The tracked balance of the loan at the previewed period.
         uint256 outstandingBalance; // The outstanding balance of the loan at the previewed period.
+    }
+
+    /// @dev TODO
+    struct InstallmentLoanPreview {
+        uint256 firstInstallmentId;
+        uint256 instalmentCount;
+        uint256 periodIndex;
+        uint256 totalTrackedBalance;
+        uint256 totalOutstandingBalance;
     }
 }

--- a/contracts/mocks/CreditLineMock.sol
+++ b/contracts/mocks/CreditLineMock.sol
@@ -26,7 +26,7 @@ contract CreditLineMock is ICreditLine {
 
     address private _tokenAddress;
 
-    mapping(address => mapping(uint256 => Loan.Terms)) private _loanTerms;
+    mapping(address => Loan.Terms) private _loanTerms;
 
     bool private _onBeforeLoanTakenResult;
 
@@ -58,8 +58,9 @@ contract CreditLineMock is ICreditLine {
         uint256 borrowAmount,
         uint256 durationInPeriods
     ) external view returns (Loan.Terms memory terms) {
-        durationInPeriods; // To prevent compiler warning about unused variable
-        return _loanTerms[borrower][borrowAmount];
+        borrowAmount; // To prevent compiler warning about unused variable
+        terms = _loanTerms[borrower];
+        terms.durationInPeriods = uint32(durationInPeriods);
     }
 
     function market() external pure returns (address) {
@@ -83,7 +84,8 @@ contract CreditLineMock is ICreditLine {
     }
 
     function mockLoanTerms(address borrower, uint256 amount, Loan.Terms memory terms) external {
-        _loanTerms[borrower][amount] = terms;
+        amount; // To prevent compiler warning about unused variable
+        _loanTerms[borrower] = terms;
     }
 
     function proveCreditLine() external pure {}

--- a/contracts/mocks/LendingMarketMock.sol
+++ b/contracts/mocks/LendingMarketMock.sol
@@ -154,8 +154,22 @@ contract LendingMarketMock is ILendingMarket {
         return _loanStates[loanId];
     }
 
+    function getLoanStateBatch(uint256[] calldata loanIds) external pure returns (Loan.State[] memory) {
+        loanIds; // To prevent compiler warning about unused variable
+        revert Error.NotImplemented();
+    }
+
     function getLoanPreview(uint256 loanId, uint256 timestamp) external pure returns (Loan.Preview memory) {
         loanId; // To prevent compiler warning about unused variable
+        timestamp; // To prevent compiler warning about unused variable
+        revert Error.NotImplemented();
+    }
+
+    function getLoanPreviewBatch(
+        uint256[] calldata loanIds,
+        uint256 timestamp
+    ) external pure returns (Loan.Preview[] memory) {
+        loanIds; // To prevent compiler warning about unused variable
         timestamp; // To prevent compiler warning about unused variable
         revert Error.NotImplemented();
     }

--- a/contracts/mocks/LendingMarketMock.sol
+++ b/contracts/mocks/LendingMarketMock.sol
@@ -166,6 +166,12 @@ contract LendingMarketMock is ILendingMarket {
         revert Error.NotImplemented();
     }
 
+    function isProgramLenderOrAlias(uint32 programId, address account) external pure returns (bool) {
+        programId; // To prevent compiler warning about unused variable
+        account; // To prevent compiler warning about unused variable
+        revert Error.NotImplemented();
+    }
+
     function hasAlias(address lender, address account) external pure returns (bool) {
         lender; // To prevent compiler warning about unused variable
         account; // To prevent compiler warning about unused variable

--- a/contracts/mocks/LendingMarketMock.sol
+++ b/contracts/mocks/LendingMarketMock.sol
@@ -160,6 +160,15 @@ contract LendingMarketMock is ILendingMarket {
         revert Error.NotImplemented();
     }
 
+    function getInstallmentLoanPreview(
+        uint256 loanId,
+        uint256 timestamp
+    ) external pure returns (Loan.InstallmentLoanPreview memory) {
+        loanId; // To prevent compiler warning about unused variable
+        timestamp; // To prevent compiler warning about unused variable
+        revert Error.NotImplemented();
+    }
+
     function isLenderOrAlias(uint256 loanId, address account) external pure returns (bool) {
         loanId; // To prevent compiler warning about unused variable
         account; // To prevent compiler warning about unused variable

--- a/contracts/mocks/LendingMarketMock.sol
+++ b/contracts/mocks/LendingMarketMock.sol
@@ -79,6 +79,23 @@ contract LendingMarketMock is ILendingMarket {
         revert Error.NotImplemented();
     }
 
+    function takeInstallmentLoanFor(
+        address borrower,
+        uint32 programId,
+        uint256[] calldata borrowAmounts,
+        uint256[] calldata addonAmounts,
+        uint256[] calldata durationInPeriods
+    ) external pure returns (uint256 firstInstallmentId, uint256 installmentCount) {
+        borrower; // To prevent compiler warning about unused variable
+        programId; // To prevent compiler warning about unused variable
+        borrowAmounts; // To prevent compiler warning about unused variable
+        addonAmounts; // To prevent compiler warning about unused variable
+        durationInPeriods; // To prevent compiler warning about unused variable
+        firstInstallmentId = 0;
+        installmentCount = 0;
+        revert Error.NotImplemented();
+    }
+
     function repayLoan(uint256 loanId, uint256 repayAmount) external {
         loanId; // To prevent compiler warning about unused variable
         repayAmount; // To prevent compiler warning about unused variable

--- a/contracts/mocks/LendingMarketMock.sol
+++ b/contracts/mocks/LendingMarketMock.sol
@@ -101,6 +101,11 @@ contract LendingMarketMock is ILendingMarket {
         revert Error.NotImplemented();
     }
 
+    function revokeInstallmentLoan(uint256 loanId) external pure {
+        loanId; // To prevent compiler warning about unused variable
+        revert Error.NotImplemented();
+    }
+
     function updateLoanDuration(uint256 loanId, uint256 newDurationInPeriods) external pure {
         loanId; // To prevent compiler warning about unused variable
         newDurationInPeriods; // To prevent compiler warning about unused variable

--- a/contracts/mocks/LendingMarketMock.sol
+++ b/contracts/mocks/LendingMarketMock.sol
@@ -84,13 +84,13 @@ contract LendingMarketMock is ILendingMarket {
         uint32 programId,
         uint256[] calldata borrowAmounts,
         uint256[] calldata addonAmounts,
-        uint256[] calldata durationInPeriods
+        uint256[] calldata durationsInPeriods
     ) external pure returns (uint256 firstInstallmentId, uint256 installmentCount) {
         borrower; // To prevent compiler warning about unused variable
         programId; // To prevent compiler warning about unused variable
         borrowAmounts; // To prevent compiler warning about unused variable
         addonAmounts; // To prevent compiler warning about unused variable
-        durationInPeriods; // To prevent compiler warning about unused variable
+        durationsInPeriods; // To prevent compiler warning about unused variable
         firstInstallmentId = 0;
         installmentCount = 0;
         revert Error.NotImplemented();

--- a/contracts/testables/LendingMarketTestable.sol
+++ b/contracts/testables/LendingMarketTestable.sol
@@ -12,7 +12,7 @@ contract LendingMarketTestable is LendingMarket {
     uint256 public installmentCountMax;
 
     /// @dev Sets a new loan ID counter for testing.
-    /// @param newValue The new loan ID counter value.  
+    /// @param newValue The new loan ID counter value.
     function setLoanIdCounter(uint256 newValue) external {
         _loanIdCounter = newValue;
     }
@@ -38,7 +38,7 @@ contract LendingMarketTestable is LendingMarket {
     }
 
     /// @dev Overrides the same name function in the lending market contract to return the testable value if set.
-    /// @return The maximum number of installments. 
+    /// @return The maximum number of installments.
     function _installmentCountMax() internal view override returns (uint256) {
         if (installmentCountMax == 0) {
             return super._installmentCountMax();

--- a/contracts/testables/LendingMarketTestable.sol
+++ b/contracts/testables/LendingMarketTestable.sol
@@ -11,6 +11,12 @@ contract LendingMarketTestable is LendingMarket {
     /// @dev The maximum number of installments. Non-zero value overrides the constant in Constants.sol.
     uint256 public installmentCountMax;
 
+    /// @dev Sets a new loan ID counter for testing.
+    /// @param newValue The new loan ID counter value.  
+    function setLoanIdCounter(uint256 newValue) external {
+        _loanIdCounter = newValue;
+    }
+
     /// @dev Sets a new credit line address for a lending program.
     /// @param programId The ID of the lending program.
     /// @param newCreditLine The new address of the credit line to set.

--- a/contracts/testables/LendingMarketTestable.sol
+++ b/contracts/testables/LendingMarketTestable.sol
@@ -8,6 +8,9 @@ import { LendingMarket } from "../LendingMarket.sol";
 /// @author CloudWalk Inc. (See https://cloudwalk.io)
 /// @dev Version of the lending market contract with additions required for testing.
 contract LendingMarketTestable is LendingMarket {
+    /// @dev The maximum number of installments. Non-zero value overrides the constant in Constants.sol.
+    uint256 public installmentCountMax;
+
     /// @dev Sets a new credit line address for a lending program.
     /// @param programId The ID of the lending program.
     /// @param newCreditLine The new address of the credit line to set.
@@ -20,5 +23,21 @@ contract LendingMarketTestable is LendingMarket {
     /// @param newLiquidityPool The new address of the liquidity pool to set.
     function setLiquidityPoolForProgram(uint32 programId, address newLiquidityPool) external {
         _programLiquidityPools[programId] = newLiquidityPool;
+    }
+
+    /// @dev Sets a new maximum number of installments. Non-zero value overrides the constant in Constants.sol.
+    /// @param newValue The new maximum number of installments.
+    function setInstallmentCountMax(uint256 newValue) external {
+        installmentCountMax = newValue;
+    }
+
+    /// @dev Overrides the same name function in the lending market contract to return the testable value if set.
+    /// @return The maximum number of installments. 
+    function _installmentCountMax() internal view override returns (uint256) {
+        if (installmentCountMax == 0) {
+            return super._installmentCountMax();
+        } else {
+            return installmentCountMax;
+        }
     }
 }

--- a/test-utils/common.ts
+++ b/test-utils/common.ts
@@ -3,7 +3,7 @@ import { network } from "hardhat";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 
 export function checkEquality<T extends Record<string, unknown>>(actualObject: T, expectedObject: T, index?: number) {
-  const indexString = !index ? "" : ` with index: ${index}`;
+  const indexString = index == null ? "" : ` with index: ${index}`;
   Object.keys(expectedObject).forEach(property => {
     const value = actualObject[property];
     if (typeof value === "undefined" || typeof value === "function") {

--- a/test/LendingMarket.base.test.ts
+++ b/test/LendingMarket.base.test.ts
@@ -114,6 +114,7 @@ const ERROR_NAME_DURATION_ARRAY_INVALID = "DurationArrayInvalid";
 const ERROR_NAME_INSTALLMENT_COUNT_EXCESS = "InstallmentCountExcess";
 const ERROR_NAME_ARRAY_LENGTH_MISMATCH = "ArrayLengthMismatch";
 const ERROR_NAME_LOAN_TYPE_UNEXPECTED = "LoanTypeUnexpected";
+const ERROR_NAME_LOAN_ID_EXCESS = "LoanIdExcess";
 
 const EVENT_NAME_CREDIT_LINE_REGISTERED = "CreditLineRegistered";
 const EVENT_NAME_LENDER_ALIAS_CONFIGURED = "LenderAliasConfigured";
@@ -1220,6 +1221,21 @@ describe("Contract 'LendingMarket': base tests", async () => {
         )
       ).to.be.revertedWithCustomError(marketUnderLender, ERROR_NAME_LIQUIDITY_POOL_LENDER_NOT_CONFIGURED);
     });
+
+    it("Is reverted if the loan ID counter is greater than the max allowed value", async () => {
+      const { marketUnderLender } = await setUpFixture(deployLendingMarketAndConfigureItForLoan);
+      await proveTx(marketUnderLender.setLoanIdCounter(maxUintForBits(40) + 1n));
+
+      await expect(
+        marketUnderLender.takeLoanFor(
+          borrower.address,
+          PROGRAM_ID,
+          BORROW_AMOUNT,
+          ADDON_AMOUNT,
+          DURATION_IN_PERIODS
+        )
+      ).to.be.revertedWithCustomError(marketUnderLender, ERROR_NAME_LOAN_ID_EXCESS);
+    });
   });
 
   describe("Function 'takeInstallmentLoanFor()'", async () => {
@@ -1567,6 +1583,21 @@ describe("Contract 'LendingMarket': base tests", async () => {
           DURATIONS_IN_PERIODS
         )
       ).to.be.revertedWithCustomError(marketUnderLender, ERROR_NAME_LIQUIDITY_POOL_LENDER_NOT_CONFIGURED);
+    });
+
+    it("Is reverted if the loan ID counter is greater than the max allowed value", async () => {
+      const { marketUnderLender } = await setUpFixture(deployLendingMarketAndConfigureItForLoan);
+      await proveTx(marketUnderLender.setLoanIdCounter(maxUintForBits(40) + 2n - BigInt(INSTALLMENT_COUNT)));
+
+      await expect(
+        marketUnderLender.takeInstallmentLoanFor(
+          borrower.address,
+          PROGRAM_ID,
+          BORROW_AMOUNTS,
+          ADDON_AMOUNTS,
+          DURATIONS_IN_PERIODS
+        )
+      ).to.be.revertedWithCustomError(marketUnderLender, ERROR_NAME_LOAN_ID_EXCESS);
     });
   });
 

--- a/test/LendingMarket.base.test.ts
+++ b/test/LendingMarket.base.test.ts
@@ -164,7 +164,7 @@ const DURATIONS_IN_PERIODS: number[] = [0, DURATION_IN_PERIODS / 2, DURATION_IN_
 
 const EXPECTED_VERSION: Version = {
   major: 1,
-  minor: 3,
+  minor: 4,
   patch: 0
 };
 

--- a/test/LendingMarket.base.test.ts
+++ b/test/LendingMarket.base.test.ts
@@ -35,6 +35,8 @@ interface LoanState {
   trackedBalance: number;
   trackedTimestamp: number;
   freezeTimestamp: number;
+  firstInstallmentId: number;
+  instalmentCount: number;
 
   [key: string]: string | number; // Index signature
 }
@@ -157,7 +159,9 @@ const defaultLoanState: LoanState = {
   repaidAmount: 0,
   trackedBalance: 0,
   trackedTimestamp: 0,
-  freezeTimestamp: 0
+  freezeTimestamp: 0,
+  firstInstallmentId: 0,
+  instalmentCount: 0
 };
 
 async function deployAndConnectContract(

--- a/test/credit-lines/CreditLineConfigurable.test.ts
+++ b/test/credit-lines/CreditLineConfigurable.test.ts
@@ -204,7 +204,7 @@ const REPAY_AMOUNT = 12345678n;
 
 const EXPECTED_VERSION: Version = {
   major: 1,
-  minor: 3,
+  minor: 4,
   patch: 0
 };
 

--- a/test/credit-lines/CreditLineConfigurable.test.ts
+++ b/test/credit-lines/CreditLineConfigurable.test.ts
@@ -76,6 +76,8 @@ interface LoanState {
   trackedBalance: bigint;
   trackedTimestamp: bigint;
   freezeTimestamp: bigint;
+  firstInstallmentId: bigint;
+  instalmentCount: bigint;
 }
 
 interface Version {
@@ -146,7 +148,9 @@ const defaultLoanState: LoanState = {
   repaidAmount: 0n,
   trackedBalance: 0n,
   trackedTimestamp: 0n,
-  freezeTimestamp: 0n
+  freezeTimestamp: 0n,
+  firstInstallmentId: 0n,
+  instalmentCount: 0n
 };
 
 const ERROR_NAME_ACCESS_CONTROL_UNAUTHORIZED = "AccessControlUnauthorizedAccount";

--- a/test/liquidity-pools/LiquidityPoolAccountable.test.ts
+++ b/test/liquidity-pools/LiquidityPoolAccountable.test.ts
@@ -74,7 +74,7 @@ const AUTO_REPAY_LOAN_IDS = [123n, 234n, 345n, 123n];
 const AUTO_REPAY_AMOUNTS = [10_123_456n, 1n, maxUintForBits(256), 0n];
 const EXPECTED_VERSION: Version = {
   major: 1,
-  minor: 3,
+  minor: 4,
   patch: 0
 };
 

--- a/test/liquidity-pools/LiquidityPoolAccountable.test.ts
+++ b/test/liquidity-pools/LiquidityPoolAccountable.test.ts
@@ -19,6 +19,8 @@ interface LoanState {
   trackedBalance: bigint;
   trackedTimestamp: bigint;
   freezeTimestamp: bigint;
+  firstInstallmentId: bigint;
+  instalmentCount: bigint;
 }
 
 interface Version {
@@ -89,7 +91,9 @@ const defaultLoanState: LoanState = {
   repaidAmount: 0n,
   trackedBalance: 0n,
   trackedTimestamp: 0n,
-  freezeTimestamp: 0n
+  freezeTimestamp: 0n,
+  firstInstallmentId: 0n,
+  instalmentCount: 0n
 };
 
 describe("Contract 'LiquidityPoolAccountable'", async () => {

--- a/test/mocks/LendingMarketMock.test.ts
+++ b/test/mocks/LendingMarketMock.test.ts
@@ -105,6 +105,13 @@ describe("Contract 'LendingMarketMock'", async () => {
         .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
     });
 
+    it("Function 'revokeInstallmentLoan()'", async () => {
+      const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
+
+      await expect(lendingMarket.revokeInstallmentLoan(MOCK_LOAN_ID))
+        .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
+    });
+
     it("Function 'updateLoanDuration()'", async () => {
       const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
 

--- a/test/mocks/LendingMarketMock.test.ts
+++ b/test/mocks/LendingMarketMock.test.ts
@@ -182,6 +182,13 @@ describe("Contract 'LendingMarketMock'", async () => {
         .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
     });
 
+    it("Function 'isProgramLenderOrAlias()'", async () => {
+      const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
+
+      await expect(lendingMarket.isProgramLenderOrAlias(MOCK_PROGRAM_ID, MOCK_ADDRESS))
+        .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
+    });
+
     it("Function 'hasAlias()'", async () => {
       const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
 

--- a/test/mocks/LendingMarketMock.test.ts
+++ b/test/mocks/LendingMarketMock.test.ts
@@ -182,10 +182,24 @@ describe("Contract 'LendingMarketMock'", async () => {
         .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
     });
 
+    it("Function 'getLoanStateBatch()'", async () => {
+      const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
+
+      await expect(lendingMarket.getLoanStateBatch([MOCK_LOAN_ID]))
+        .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
+    });
+
     it("Function 'getLoanPreview()'", async () => {
       const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
 
-      await expect(lendingMarket.getLoanPreview(MOCK_LOAN_ID, MOCK_ADDRESS))
+      await expect(lendingMarket.getLoanPreview(MOCK_LOAN_ID, 0))
+        .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
+    });
+
+    it("Function 'getLoanPreviewBatch()'", async () => {
+      const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
+
+      await expect(lendingMarket.getLoanPreviewBatch([MOCK_LOAN_ID], 0))
         .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
     });
 

--- a/test/mocks/LendingMarketMock.test.ts
+++ b/test/mocks/LendingMarketMock.test.ts
@@ -84,6 +84,13 @@ describe("Contract 'LendingMarketMock'", async () => {
         .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
     });
 
+    it("Function 'takeInstallmentLoanFor()'", async () => {
+      const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
+
+      await expect(lendingMarket.takeInstallmentLoanFor(MOCK_ADDRESS, MOCK_PROGRAM_ID, [], [], []))
+        .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
+    });
+
     it("Function 'freeze()'", async () => {
       const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
 

--- a/test/mocks/LendingMarketMock.test.ts
+++ b/test/mocks/LendingMarketMock.test.ts
@@ -175,6 +175,13 @@ describe("Contract 'LendingMarketMock'", async () => {
         .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
     });
 
+    it("Function 'getInstallmentLoanPreview()'", async () => {
+      const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
+
+      await expect(lendingMarket.getInstallmentLoanPreview(MOCK_LOAN_ID, MOCK_ADDRESS))
+        .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
+    });
+
     it("Function 'isLenderOrAlias()'", async () => {
       const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
 


### PR DESCRIPTION
## Main changes
1. A possibility to process installment loans has been added to the lending market smart-contract.
2. Each installment loan consists of several sub-loans that represent installments. The whole installment loan is addressed by ID of any of its installments (sub-loans).
3. Loans that were taken out before this change are now called `ordinary`. Throughout the code, the terms `loan` (without additional specification), `sub-loan`, and `installment` are used interchangeably since they all represent the same underlying loan structure in the smart contract. Unless otherwise specified, a smart-contract function is applicable to both ordinary loans and sub-loans.
4.  The `Loan.State` structure that stores data of a loan has been extended with two new fields:
    * a. `firstInstallmentId` -- contains the ID of the first installment for sub-loans or zero for ordinary loans.
    * b.  `instalmentCount` -- contains the total number of installments for sub-loans or zero for ordinary loans.
    
        <details>
        
        <summary>The new definition of the structure </summary>
    
        ```solidity
        /// @dev A struct that defines the stored state of a loan.
        struct State {
            // Slot1
            uint32 programId;             // The unique identifier of the program.
            uint64 borrowAmount;          // The initial borrow amount of the loan, excluding the addon.
            uint64 addonAmount;           // The amount of the loan addon (extra charges or fees).
            uint32 startTimestamp;        // The timestamp when the loan was created (stated).
            uint32 durationInPeriods;     // The total duration of the loan determined by the number of periods.
            // uint32 __reserved;         // Reserved for future use.
            // Slot 2
            address token;                // The address of the token used for the loan.
            // uint96 __reserved;         // Reserved for future use.
            // Slot 3
            address borrower;             // The address of the borrower.
            uint32 interestRatePrimary;   // The primary interest rate that is applied to the loan.
            uint32 interestRateSecondary; // The secondary interest rate that is applied to the loan.
            // uint32 __reserved;         // Reserved for future use.
            // Slot 4
            uint64 repaidAmount;          // The amount that has been repaid on the loan over its lifetime.
            uint64 trackedBalance;        // The borrow balance of the loan that is tracked over its lifetime.
            uint32 trackedTimestamp;      // The timestamp when the loan was last paid or its balance was updated.
            uint32 freezeTimestamp;       // The timestamp when the loan was frozen. Zero value for unfrozen loans.
            uint40 firstInstallmentId;    // The ID of the first installment for sub-loans or zero for ordinary loans.
            uint16 instalmentCount;       // The total number of installments for sub-loans or zero for ordinary loans.
            // uint8 __reserved;          // Reserved for future use.
        }
        ```
        
        </details>
5.  The new `takeInstallmentLoanFor()` function has been introduced to take installment loans. Key points of the function:
    * a. The new function can be called only by the lender or by an account that configured as the lander alias.
    * b.  Any element in the input `borrowAmounts` array can be unrounded, but the sum of all elements must be rounded according to the `ACCURACY_FACTOR` constant.
    * c. Any element in the input `addonAmounts` array can be unrounded, but the sum of all elements must be rounded according to the `ACCURACY_FACTOR` constant.
    * d. The elements of the input array `durationsInPeriods` must be a non-decreasing series of values. A valid array example: `[0, 0, 1, 2, 2, 3, 4]`. An invalid array example: `[1, 2, 3, 2]`.
    * e. If successful, the function emits the exiting `LoanTaken` event for each sub-loan and the new `InstallmentLoanTaken` event for the installment loan as a whole.
        
        <details>
        
        <summary>The new function definition </summary>
    
        ```solidity
        /// @dev Takes an installment loan with multiple sub-loans for a provided account.
        ///
        /// Can be called only by an account with a special role.
        ///
        /// @param borrower The account for whom the loan is taken.
        /// @param programId The identifier of the program to take the loan from.
        /// @param borrowAmounts The desired amounts of tokens to borrow for each installment.
        /// @param addonAmounts The off-chain calculated addon amounts for each installment.
        /// @param durationsInPeriods The desired duration of each installment in periods.
        /// @return firstInstallmentId The unique identifier of the first sub-loan of the installment loan.
        /// @return installmentCount The total number of installments.
        function takeInstallmentLoanFor(
            address borrower,
            uint32 programId,
            uint256[] calldata borrowAmounts,
            uint256[] calldata addonAmounts,
            uint256[] calldata durationsInPeriods
        ) external whenNotPaused returns (uint256 firstInstallmentId, uint256 installmentCount) {....}
        ```
        
        </details>
        
        <details>
        
        <summary>The new event definition </summary>
    
        ```solidity
        /// @dev Emitted when an installment loan is taken in the form of multiple sub-loans.
        /// @param firstInstallmentId The ID of the first sub-loan of the installment loan.
        /// @param borrower The address of the borrower.
        /// @param programId The ID of the lending program.
        /// @param installmentCount The total number of installments.
        /// @param totalBorrowAmount The total amount borrowed.
        /// @param totalAddonAmount The total addon amount of the loan.
        event InstallmentLoanTaken(
            uint256 indexed firstInstallmentId,
            address indexed borrower,
            uint256 indexed programId,
            uint256 installmentCount,
            uint256 totalBorrowAmount,
            uint256 totalAddonAmount
        );
        ```
        
        </details>

6. The new `revokeInstallmentLoan()` function has been introduced to revoke installment loans. Key points of the function:
    * a. The function can be called by the borrower before the end of the cooldown period (3 days after the loan started). After the cooldown period the appropriate transaction will be reverted.
    * b. The new function can be called by the lender or by an account that configured as the lander alias regardless of the cooldown period.
    * c. The function revokes all sub-loans of of the installment loan.
    * d. The function MUST NOT be called for ordinary loans. The related transaction will be reverted in that case.
    * e. The function MUST NOT be called for repaid installment loans i.e. if all their sub-loans has the zero tracked balance. The related transaction will be reverted in that case.
    * f. If successful, the function emits the exiting `LoanRevoked` event for each sub-loan and the new `InstallmentLoanRevoked` event for the installment loan as a whole.

        <details>
        
        <summary>The new function definition </summary>
    
        ```solidity
        /// @dev Revokes an installment loan by revoking all of its sub-loans.
        /// @param loanId The unique identifier of any sub-loan of the installment loan to revoke.
        function revokeInstallmentLoan(uint256 loanId) external whenNotPaused {....}
        ```
        
        </details>

        <details>
        
        <summary>The new event definition </summary>
    
        ```solidity
        /// @dev Emitted when an installment loan is revoked.
        /// @param firstInstallmentId The ID of the first sub-loan of the installment loan.
        /// @param installmentCount The total number of installments.
        event InstallmentLoanRevoked(
            uint256 indexed firstInstallmentId, // Tools: this comment prevents Prettier from formatting into a single line.
            uint256 installmentCount
        );
        ```
        
        </details>

7. The existing `revokeLoan()` function MUST NOT be called for any sub-loan of an installment loan. In that case the related transaction will be reverted. Other existing functions like `repayLoan()`, `freeze()`, `unfreeze()`, etc. can be called for sub-loans of an installment loan the same way as for ordinary loans.

8. The new `getInstallmentLoanPreview()` function has been introduced get the preview of an installment loan at a specific timestamp. Key points of the function:
    * a. The function returns the new `Loan.InstallmentLoanPreview` structure.
    * b. The function can be called for an ordinary loan as well, but the resulting data will be slightly different.
    * c. The function can be called with a loan ID that belongs to a non-existent loan. In that case the result balances will be zero.
    
        <details>
        
        <summary>The new function definition </summary>
    
        ```solidity
        /// @dev Gets the preview of an installment loan at a specific timestamp.
        ///
        /// This function can be called for an ordinary loan as well, but the resulting data will be slightly different.
        /// See additional comments for the the `Loan.InstallmentLoanPreview` structure
        ///
        /// @param loanId The unique identifier of any sub-loan of the installment loan to check.
        /// @param timestamp The timestamp to get the installment loan preview for. If 0, the current timestamp is used.
        /// @return The preview state of the installment loan (see the `Loan.InstallmentLoanPreview` structure).
        function getInstallmentLoanPreview(
            uint256 loanId,
            uint256 timestamp
        ) external view returns (Loan.InstallmentLoanPreview memory) {....}
        ```
        
        </details>

        <details>
        
        <summary>The new structure definition </summary>
    
        ```solidity
        /// @dev A struct that defines the preview of an installment loan.
        ///
        /// The structure can be returned for both ordinary and installment loans.
        ///
        /// The purpose of the fields in the case of installment loans:
        ///
        /// - firstInstallmentId ------- The first installment ID.
        /// - instalmentCount ---------- The total number of installments.
        /// - periodIndex -------------- The period index that matches the preview timestamp.
        /// - totalTrackedBalance ------ The total tracked balance of all installments.
        /// - totalOutstandingBalance -- The total outstanding balance of all installments.
        ///
        /// The purpose of the fields in the case of ordinary loans:
        ///
        /// - firstInstallmentId ------- The ID of the loan.
        /// - instalmentCount ---------- The total number of installments that always equals zero.
        /// - periodIndex -------------- The period index that matches the preview timestamp.
        /// - totalTrackedBalance ------ The tracked balance of the loan.
        /// - totalOutstandingBalance -- The outstanding balance of the loan.
        ///
        /// Notes:
        ///
        /// 1. The `totalTrackedBalance` fields calculates as the sum of tracked balances of all installments.
        /// 2. The `totalOutstandingBalance` fields calculates as the sum of rounded tracked balances
        ///    of all installments according to the `ACCURACY_FACTOR` constant.
        struct InstallmentLoanPreview {
            uint256 firstInstallmentId;      
            uint256 instalmentCount;
            uint256 periodIndex;
            uint256 totalTrackedBalance;
            uint256 totalOutstandingBalance;
        }
        ```
        
        </details>

9. The new `getLoanStateBatch()` function has been introduced to get the stored state of a batch of loans. It is similar to the existing `getLoanState()` function, but takes an array of loan IDs instead of a single ID and allows to speed up fetching data of multiple loans.
    <details>
    
    <summary>The new function definition </summary>
    
    ```solidity
    /// @dev Gets the stored state of a batch of ordinary loans or sub-loans.
    /// @param loanIds The unique identifiers of the loans to check.
    /// @return The stored states of the loans (see the `Loan.State` struct).
    function getLoanStateBatch(uint256[] calldata loanIds) external view returns (Loan.State[] memory) {....}
    ```
    
    </details>
   
10. The new `getLoanPreviewBatch()` function has been introduced to get the preview at a specific timestamp for a batch of loans. It is similar to the existing `getLoanPreview()` function, but takes an array of loan IDs instead of a single ID and allows to speed up fetching data of multiple loans.
    <details>
    
    <summary>The new function definition </summary>
    
    ```solidity
    function getLoanPreviewBatch(
        uint256[] calldata loanIds,
        uint256 timestamp
    ) external view returns (Loan.Preview[] memory) {....}
    ```
    
    </details>

11. The new `isProgramLenderOrAlias()` function has been introduced to check if the provided account is a lender or an alias for the given lending program.

    <details>
    
    <summary>The new function definition </summary>
    
    ```solidity
    /// @dev Checks if the provided account is a lender or an alias for a lender of a given lending program.
    /// @param programId The identifier of the program to check.
    /// @param account The address to check whether it's a lender or an alias.
    function isProgramLenderOrAlias(uint32 programId, address account) public view returns (bool) {....}
    ```
    
    </details>
    
## Versioning
The new version of the contracts is `1.4.0`.

## Test Coverage

The new function and logic are fully covered by tests.

<details>

<summary>Test coverage details</summary>

| File                                    |  % Stmts | % Branch |  % Funcs |  % Lines |
|-----------------------------------------|---------:|---------:|---------:|---------:|
| contracts/                              |   100.00 |    99.00 |   100.00 |   100.00 |
| ├─ LendingMarket.sol                    |   100.00 |    98.99 |   100.00 |   100.00 |
| ├─ LendingMarketStorage.sol             |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketUUPS.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/                       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeable.sol      |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/interfaces/            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICreditLineConfigurable.sol          |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILiquidityPoolAccountable.sol        |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/interfaces/core/       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICreditLine.sol                      |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILendingMarket.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILiquidityPool.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/libraries/             |   100.00 |    70.00 |   100.00 |    100.00 |
| ├─ ABDKMath64x64.sol                    |   100.00 |    65.91 |   100.00 |    100.00 |
| ├─ Constants.sol                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Error.sol                            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ InterestMath.sol                     |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Loan.sol                             |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Round.sol                            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ SafeCast.sol                         |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/credit-lines/                 |   100.00 |    97.37 |   100.00 |   100.00 |
| ├─ CreditLineConfigurable.sol           |   100.00 |    97.32 |   100.00 |   100.00 |
| ├─ CreditLineConfigurableUUPS.sol       |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/liquidity-pools/              |   100.00 |    97.22 |   100.00 |   100.00 |
| ├─ LiquidityPoolAccountable.sol         |   100.00 |    97.14 |   100.00 |   100.00 |
| ├─ LiquidityPoolAccountableUUPS.sol     |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/mocks/                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeableMock.sol  |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineMock.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ERC20Mock.sol                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketMock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPoolMock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/testables/                    |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineConfigurableTestable.sol   |   100.00 |   100.00 |   100.00 |   100.00 |
|-----------------------------------------|----------|----------|----------|----------|
| All files                               |   100.00 |    95.13 |   100.00 |    100.00 |
|-----------------------------------------|----------|----------|----------|----------|
</details>
