### PR TITLE
feat: late fee imposing, transfer consolidation, new view functions

### DIFF
--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -1022,7 +1022,7 @@ contract LendingMarket is
         Loan.Preview memory preview;
         Loan.State storage loan = _loans[loanId];
 
-        (preview.trackedBalance, /* skip the late fee */, preview.periodIndex) = _outstandingBalance(loan, timestamp);
+        (preview.trackedBalance /* skip the late fee */, , preview.periodIndex) = _outstandingBalance(loan, timestamp);
         preview.outstandingBalance = Rounding.roundMath(preview.trackedBalance, Constants.ACCURACY_FACTOR);
 
         return preview;
@@ -1064,7 +1064,7 @@ contract LendingMarket is
     /// @param loan The storage state of the loan.
     /// @return The late fee amount.
     function _calculateLateFee(
-        uint256 outstandingBalance,
+        uint256 outstandingBalance, // Tools: this comment prevents Prettier from formatting into a single line.
         Loan.State storage loan
     ) internal view returns (uint256) {
         address creditLine = _programCreditLines[loan.programId];

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -19,7 +19,6 @@ import { Versionable } from "./common/Versionable.sol";
 import { ILendingMarket } from "./common/interfaces/core/ILendingMarket.sol";
 import { ILiquidityPool } from "./common/interfaces/core/ILiquidityPool.sol";
 import { ICreditLine } from "./common/interfaces/core/ICreditLine.sol";
-import { ICreditLineConfigurable } from "./common/interfaces/ICreditLineConfigurable.sol";
 
 import { LendingMarketStorage } from "./LendingMarketStorage.sol";
 
@@ -1068,7 +1067,7 @@ contract LendingMarket is
         Loan.State storage loan
     ) internal view returns (uint256) {
         address creditLine = _programCreditLines[loan.programId];
-        uint256 lateFeeRate = creditLine != address(0) ? ICreditLineConfigurable(creditLine).lateFeeRate() : 0;
+        uint256 lateFeeRate = creditLine != address(0) ? ICreditLine(creditLine).lateFeeRate() : 0;
         uint256 product = outstandingBalance * lateFeeRate;
         uint256 reminder = product % Constants.INTEREST_RATE_FACTOR;
         uint256 result = product / Constants.INTEREST_RATE_FACTOR;

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -1003,7 +1003,10 @@ contract LendingMarket is
     /// @param loanId The ID of the loan.
     /// @param timestamp The timestamp to calculate the preview at.
     /// @return The loan extended preview.
-    function _getLoanPreviewExtended(uint256 loanId, uint256 timestamp) internal view returns (Loan.PreviewExtended memory) {
+    function _getLoanPreviewExtended(
+        uint256 loanId,
+        uint256 timestamp
+    ) internal view returns (Loan.PreviewExtended memory) {
         Loan.PreviewExtended memory preview;
         Loan.State storage loan = _loans[loanId];
 

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -287,24 +287,19 @@ contract LendingMarket is
         uint256 principalAmount = borrowAmount + terms.addonAmount;
         uint32 blockTimestamp = _blockTimestamp().toUint32();
 
-        _loans[id] = Loan.State({
-            token: terms.token,
-            borrower: borrower,
-            programId: programId,
-            startTimestamp: blockTimestamp,
-            durationInPeriods: terms.durationInPeriods,
-            interestRatePrimary: terms.interestRatePrimary,
-            interestRateSecondary: terms.interestRateSecondary,
-            borrowAmount: borrowAmount.toUint64(),
-            trackedBalance: principalAmount.toUint64(),
-            repaidAmount: 0,
-            trackedTimestamp: blockTimestamp,
-            freezeTimestamp: 0,
-            addonAmount: terms.addonAmount,
-            firstInstallmentId: 0,
-            instalmentCount: 0,
-            lateFeeAmount: 0
-        });
+        Loan.State storage loan = _loans[id];
+        loan.token = terms.token;
+        loan.borrower = borrower;
+        loan.programId = programId;
+        loan.startTimestamp = blockTimestamp;
+        loan.durationInPeriods = terms.durationInPeriods;
+        loan.interestRatePrimary = terms.interestRatePrimary;
+        loan.interestRateSecondary = terms.interestRateSecondary;
+        loan.borrowAmount = borrowAmount.toUint64();
+        loan.trackedBalance = principalAmount.toUint64();
+        loan.trackedTimestamp = blockTimestamp;
+        loan.addonAmount = terms.addonAmount;
+        // Other loan fields are zero: repaidAmount, repaidAmount, firstInstallmentId, lateFeeAmount
 
         ICreditLine(creditLine).onBeforeLoanTaken(id);
         ILiquidityPool(liquidityPool).onBeforeLoanTaken(id);

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -1010,7 +1010,10 @@ contract LendingMarket is
         return preview;
     }
 
-    /// @dev TODO
+    /// @dev Calculates the installment loan preview.
+    /// @param loanId The ID of the loan.
+    /// @param timestamp The timestamp to calculate the preview at.
+    /// @return The installment loan preview.
     function _getInstallmentLoanPreview(
         uint256 loanId,
         uint256 timestamp
@@ -1104,6 +1107,10 @@ contract LendingMarket is
         }
     }
 
+    /// @dev Transfers tokens from the liquidity pool to the borrower and the addon treasury.
+    /// @param loanId The ID of the loan.
+    /// @param borrowAmount The amount of tokens to borrow.
+    /// @param addonAmount The addon amount of the loan.
     function _transferTokensOnLoanTaking(uint256 loanId, uint256 borrowAmount, uint256 addonAmount) internal {
         Loan.State storage loan = _loans[loanId];
         address liquidityPool = _programLiquidityPools[loan.programId];
@@ -1115,6 +1122,11 @@ contract LendingMarket is
         }
     }
 
+    /// @dev Transfers tokens from the borrower and the addon treasury back to the liquidity pool.
+    /// @param loan The storage state of the loan.
+    /// @param borrowAmount The amount of tokens to borrow.
+    /// @param addonAmount The addon amount of the loan.
+    /// @param repaidAmount The repaid amount of the loan.
     function _transferTokensOnLoanRevocation(
         Loan.State storage loan,
         uint256 borrowAmount,

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -599,7 +599,7 @@ contract LendingMarket is
         _checkLoanType(loan, uint256(Loan.Type.Installment));
 
         loanId = loan.firstInstallmentId;
-        uint256 lastLoanId = loanId + loan.instalmentCount - 1;
+        uint256 lastLoanId = loanId + loan.installmentCount - 1;
         uint256 ongoingSubLoanCount = 0;
         Loan.InstallmentLoanPreview memory installmentLoanPreview = _getInstallmentLoanPreview(loanId, 0);
 
@@ -618,7 +618,7 @@ contract LendingMarket is
 
         emit InstallmentLoanRevoked(
             loan.firstInstallmentId, // Tools: this comment prevents Prettier from formatting into a single line.
-            loan.instalmentCount
+            loan.installmentCount
         );
 
         _transferTokensOnLoanRevocation(
@@ -874,7 +874,7 @@ contract LendingMarket is
     ) internal {
         Loan.State storage loan = _loans[loanId];
         loan.firstInstallmentId = uint40(firstInstallmentId); // Unchecked conversion is safe due to contract logic
-        loan.instalmentCount = uint8(installmentCount); // Unchecked conversion is safe due to contract logic
+        loan.installmentCount = uint8(installmentCount); // Unchecked conversion is safe due to contract logic
     }
 
     /// @dev Validates that the loan ID is within the valid range.
@@ -912,7 +912,7 @@ contract LendingMarket is
     /// @param loan The storage state of the loan.
     /// @param expectedLoanType The expected type of the loan according to the `Loan.Type` enum.
     function _checkLoanType(Loan.State storage loan, uint256 expectedLoanType) internal view {
-        if (loan.instalmentCount == 0) {
+        if (loan.installmentCount == 0) {
             if (expectedLoanType != uint256(Loan.Type.Ordinary)) {
                 revert LoanTypeUnexpected(
                     Loan.Type.Ordinary, // actual
@@ -1026,7 +1026,7 @@ contract LendingMarket is
         preview.interestRatePrimary = loan.interestRatePrimary;
         preview.interestRateSecondary = loan.interestRateSecondary;
         preview.firstInstallmentId = loan.firstInstallmentId;
-        preview.installmentCount = loan.instalmentCount;
+        preview.installmentCount = loan.installmentCount;
 
         return preview;
     }
@@ -1044,12 +1044,12 @@ contract LendingMarket is
         }
         Loan.State storage loan = _loans[loanId];
         Loan.InstallmentLoanPreview memory preview;
-        preview.instalmentCount = loan.instalmentCount;
+        preview.installmentCount = loan.installmentCount;
         uint256 loanCount = 1;
-        if (preview.instalmentCount > 0) {
+        if (preview.installmentCount > 0) {
             loanId = loan.firstInstallmentId;
             preview.firstInstallmentId = loanId;
-            loanCount = preview.instalmentCount;
+            loanCount = preview.installmentCount;
         } else {
             preview.firstInstallmentId = loanId;
         }

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -682,41 +682,12 @@ contract LendingMarket is
     }
 
     /// @inheritdoc ILendingMarket
-    function getLoanStateBatch(uint256[] calldata loanIds) external view returns (Loan.State[] memory) {
-        uint256 len = loanIds.length;
-        Loan.State[] memory states = new Loan.State[](len);
-        for (uint256 i = 0; i < len; ++i) {
-            states[i] = _loans[loanIds[i]];
-        }
-
-        return states;
-    }
-
-    /// @inheritdoc ILendingMarket
     function getLoanPreview(uint256 loanId, uint256 timestamp) external view returns (Loan.Preview memory) {
         if (timestamp == 0) {
             timestamp = _blockTimestamp();
         }
 
         return _getLoanPreview(loanId, timestamp);
-    }
-
-    /// @inheritdoc ILendingMarket
-    function getLoanPreviewBatch(
-        uint256[] calldata loanIds,
-        uint256 timestamp
-    ) external view returns (Loan.Preview[] memory) {
-        if (timestamp == 0) {
-            timestamp = _blockTimestamp();
-        }
-
-        uint256 len = loanIds.length;
-        Loan.Preview[] memory previews = new Loan.Preview[](len);
-        for (uint256 i = 0; i < len; ++i) {
-            previews[i] = _getLoanPreview(loanIds[i], timestamp);
-        }
-
-        return previews;
     }
 
     /// @inheritdoc ILendingMarket

--- a/contracts/common/Versionable.sol
+++ b/contracts/common/Versionable.sol
@@ -16,6 +16,6 @@ abstract contract Versionable is IVersionable {
      * @inheritdoc IVersionable
      */
     function $__VERSION() external pure returns (Version memory) {
-        return Version(1, 4, 0);
+        return Version(1, 5, 0);
     }
 }

--- a/contracts/common/interfaces/ICreditLineConfigurable.sol
+++ b/contracts/common/interfaces/ICreditLineConfigurable.sol
@@ -44,6 +44,7 @@ interface ICreditLineConfigurable is ICreditLine {
         uint32 maxAddonFixedRate;        // The maximum fixed rate for the loan addon calculation.
         uint32 minAddonPeriodRate;       // The minimum period rate for the loan addon calculation.
         uint32 maxAddonPeriodRate;       // The maximum period rate for the loan addon calculation.
+        uint32 lateFeeRate;              // The late fee rate to be applied to the loan.
     }
 
     /// @dev A struct that defines borrower configuration.

--- a/contracts/common/interfaces/ILiquidityPoolAccountable.sol
+++ b/contracts/common/interfaces/ILiquidityPoolAccountable.sol
@@ -81,12 +81,4 @@ interface ILiquidityPoolAccountable is ILiquidityPool {
     /// @param account The address of the account to check.
     /// @return True if the account is configured as an admin.
     function isAdmin(address account) external view returns (bool);
-
-    /// @dev Returns the addon treasury address.
-    ///
-    /// If the address is zero the addon amount of a loan is retained in the pool.
-    /// Otherwise the addon amount transfers to that treasury when a loan is taken and back when a loan is revoked.
-    ///
-    /// @return The current address of the addon treasury.
-    function addonTreasury() external view returns (address);
 }

--- a/contracts/common/interfaces/core/ICreditLine.sol
+++ b/contracts/common/interfaces/core/ICreditLine.sol
@@ -42,6 +42,9 @@ interface ICreditLine {
     /// @dev Returns the address of the credit line token.
     function token() external view returns (address);
 
+    /// @dev Returns the late fee rate to be applied to loans taken out with this credit line.
+    function lateFeeRate() external view returns (uint256);
+
     /// @dev Proves the contract is the credit line one. A marker function.
     function proveCreditLine() external pure;
 }

--- a/contracts/common/interfaces/core/ILendingMarket.sol
+++ b/contracts/common/interfaces/core/ILendingMarket.sol
@@ -338,6 +338,15 @@ interface ILendingMarket {
         uint256 timestamp
     ) external view returns (Loan.Preview[] memory);
 
+    /// @dev Gets the loan extended preview at a specific timestamp for a batch of ordinary loans or sub-loans.
+    /// @param loanIds The unique identifiers of the loans to check.
+    /// @param timestamp The timestamp to get the loan preview for. If 0, the current timestamp is used.
+    /// @return The extended previews of the loans (see the `Loan.PreviewExtended` struct).
+    function getLoanPreviewExtendedBatch(
+        uint256[] calldata loanIds,
+        uint256 timestamp
+    ) external view returns (Loan.PreviewExtended[] memory);
+
     /// @dev Gets the preview of an installment loan at a specific timestamp.
     ///
     /// This function can be called for an ordinary loan as well, but the resulting data will be slightly different.

--- a/contracts/common/interfaces/core/ILendingMarket.sol
+++ b/contracts/common/interfaces/core/ILendingMarket.sol
@@ -318,25 +318,11 @@ interface ILendingMarket {
     /// @return The stored state of the loan (see the `Loan.State` struct).
     function getLoanState(uint256 loanId) external view returns (Loan.State memory);
 
-    /// @dev Gets the stored state of a batch of ordinary loans or sub-loans.
-    /// @param loanIds The unique identifiers of the loans to check.
-    /// @return The stored states of the loans (see the `Loan.State` struct).
-    function getLoanStateBatch(uint256[] calldata loanIds) external view returns (Loan.State[] memory);
-
     /// @dev Gets the preview of an ordinary loan or a sub-loan at a specific timestamp.
     /// @param loanId The unique identifier of the loan to check.
     /// @param timestamp The timestamp to get the loan preview for.
     /// @return The preview state of the loan (see the `Loan.Preview` struct).
     function getLoanPreview(uint256 loanId, uint256 timestamp) external view returns (Loan.Preview memory);
-
-    /// @dev Gets the loan preview at a specific timestamp for a batch of ordinary loans or sub-loans.
-    /// @param loanIds The unique identifiers of the loans to check.
-    /// @param timestamp The timestamp to get the loan preview for. If 0, the current timestamp is used.
-    /// @return The preview states of the loans (see the `Loan.Preview` struct).
-    function getLoanPreviewBatch(
-        uint256[] calldata loanIds,
-        uint256 timestamp
-    ) external view returns (Loan.Preview[] memory);
 
     /// @dev Gets the loan extended preview at a specific timestamp for a batch of ordinary loans or sub-loans.
     /// @param loanIds The unique identifiers of the loans to check.

--- a/contracts/common/interfaces/core/ILiquidityPool.sol
+++ b/contracts/common/interfaces/core/ILiquidityPool.sol
@@ -29,6 +29,14 @@ interface ILiquidityPool {
     /// @dev Returns the address of the liquidity pool token.
     function token() external view returns (address);
 
+    /// @dev Returns the addon treasury address.
+    ///
+    /// If the address is zero the addon amount of a loan is retained in the pool.
+    /// Otherwise the addon amount transfers to that treasury when a loan is taken and back when a loan is revoked.
+    ///
+    /// @return The current address of the addon treasury.
+    function addonTreasury() external view returns (address);
+
     /// @dev Proves the contract is the liquidity pool one. A marker function.
     function proveLiquidityPool() external pure;
 }

--- a/contracts/common/libraries/Loan.sol
+++ b/contracts/common/libraries/Loan.sol
@@ -41,6 +41,8 @@ library Loan {
         uint40 firstInstallmentId;    // The ID of the first installment for sub-loans or zero for ordinary loans.
         uint8 instalmentCount;        // The total number of installments for sub-loans or zero for ordinary loans.
         // uint16 __reserved;         // Reserved for future use.
+        // Slot 5
+        uint64 lateFeeAmount;         // The late fee amount of the loan or zero if the loan is not defaulted.
     }
 
     /// @dev A struct that defines the terms of the loan.

--- a/contracts/common/libraries/Loan.sol
+++ b/contracts/common/libraries/Loan.sol
@@ -45,7 +45,7 @@ library Loan {
         uint64 lateFeeAmount;         // The late fee amount of the loan or zero if the loan is not defaulted.
     }
 
-    /// @dev A struct that defines the terms of the loan.
+    /// @dev A struct that defines the terms of a loan.
     struct Terms {
         // Slot 1
         address token;                // The address of the token to be used for the loan.
@@ -63,6 +63,48 @@ library Loan {
         uint256 outstandingBalance; // The outstanding balance of the loan at the previewed period.
     }
 
+    /// @dev A struct that defines the extended preview of a loan.
+    ///
+    /// Fields:
+    /// - periodIndex ------------ The period index that matches the preview timestamp.
+    /// - trackedBalance --------- The tracked balance of the loan at the previewed period.
+    /// - outstandingBalance ----- The outstanding balance of the loan at the previewed period.
+    /// - borrowAmount ----------- The borrow amount of the loan at the previewed period.
+    /// - addonAmount ------------ The addon amount of the loan at the previewed period.
+    /// - repaidAmount ----------- The repaid amount of the loan at the previewed period.
+    /// - lateFeeAmount ---------- The late fee amount of the loan at the previewed period.
+    /// - programId -------------- The program ID of the loan.
+    /// - borrower --------------- The borrower of the loan.
+    /// - previewTimestamp ------- The preview timestamp.
+    /// - startTimestamp --------- The start timestamp of the loan.
+    /// - trackedTimestamp ------- The tracked timestamp of the loan.
+    /// - freezeTimestamp -------- The freeze timestamp of the loan.
+    /// - durationInPeriods ------ The duration in periods of the loan.
+    /// - interestRatePrimary ---- The primary interest rate of the loan.
+    /// - interestRateSecondary -- The secondary interest rate of the loan.
+    /// - firstInstallmentId ----- The ID of the first installment for sub-loans or zero for ordinary loans.
+    /// - installmentCount ------- The total number of installments for sub-loans or zero for ordinary loans.    
+    struct PreviewExtended {
+        uint256 periodIndex;
+        uint256 trackedBalance;
+        uint256 outstandingBalance;
+        uint256 borrowAmount;
+        uint256 addonAmount;
+        uint256 repaidAmount;
+        uint256 lateFeeAmount;
+        uint256 programId;
+        address borrower;
+        uint256 previewTimestamp;
+        uint256 startTimestamp;
+        uint256 trackedTimestamp;
+        uint256 freezeTimestamp;
+        uint256 durationInPeriods;
+        uint256 interestRatePrimary;
+        uint256 interestRateSecondary;
+        uint256 firstInstallmentId;
+        uint256 installmentCount;
+    }
+
     /// @dev A struct that defines the preview of an installment loan.
     ///
     /// The structure can be returned for both ordinary and installment loans.
@@ -77,6 +119,8 @@ library Loan {
     /// - totalBorrowAmount -------- The total borrow amount of all installments.
     /// - totalAddonAmount --------- The total addon amount of all installments.
     /// - totalRepaidAmount -------- The total repaid amount of all installments.
+    /// - totalLateFeeAmount ------- The total late fee amount of all installments.
+    /// - installmentPreviews ------ The extended previews of all installments.
     ///
     /// The purpose of the fields in the case of ordinary loans:
     ///
@@ -88,7 +132,9 @@ library Loan {
     /// - totalBorrowAmount -------- The borrow amount of the loan.
     /// - totalAddonAmount --------- The addon amount of the loan.
     /// - totalRepaidAmount -------- The repaid amount of the loan.
-    ///
+    /// - totalLateFeeAmount ------- The late fee amount of the loan.
+    /// - installmentPreviews ------ The extended preview of the loan as a single item array.
+
     /// Notes:
     ///
     /// 1. The `totalTrackedBalance` fields calculates as the sum of tracked balances of all installments.
@@ -103,5 +149,7 @@ library Loan {
         uint256 totalBorrowAmount;
         uint256 totalAddonAmount;
         uint256 totalRepaidAmount;
+        uint256 totalLateFeeAmount;
+        PreviewExtended[] installmentPreviews;
     }
 }

--- a/contracts/common/libraries/Loan.sol
+++ b/contracts/common/libraries/Loan.sol
@@ -89,7 +89,7 @@ library Loan {
     /// 2. The `totalOutstandingBalance` fields calculates as the sum of rounded tracked balances
     ///    of all installments according to the `ACCURACY_FACTOR` constant.
     struct InstallmentLoanPreview {
-        uint256 firstInstallmentId;      
+        uint256 firstInstallmentId;
         uint256 instalmentCount;
         uint256 periodIndex;
         uint256 totalTrackedBalance;

--- a/contracts/common/libraries/Loan.sol
+++ b/contracts/common/libraries/Loan.sol
@@ -39,7 +39,7 @@ library Loan {
         uint32 trackedTimestamp;      // The timestamp when the loan was last paid or its balance was updated.
         uint32 freezeTimestamp;       // The timestamp when the loan was frozen. Zero value for unfrozen loans.
         uint40 firstInstallmentId;    // The ID of the first installment for sub-loans or zero for ordinary loans.
-        uint8 instalmentCount;        // The total number of installments for sub-loans or zero for ordinary loans.
+        uint8 installmentCount;       // The total number of installments for sub-loans or zero for ordinary loans.
         // uint16 __reserved;         // Reserved for future use.
         // Slot 5
         uint64 lateFeeAmount;         // The late fee amount of the loan or zero if the loan is not defaulted.
@@ -112,7 +112,7 @@ library Loan {
     /// The purpose of the fields in the case of installment loans:
     ///
     /// - firstInstallmentId ------- The first installment ID.
-    /// - instalmentCount ---------- The total number of installments.
+    /// - installmentCount --------- The total number of installments.
     /// - periodIndex -------------- The period index that matches the preview timestamp.
     /// - totalTrackedBalance ------ The total tracked balance of all installments.
     /// - totalOutstandingBalance -- The total outstanding balance of all installments
@@ -125,7 +125,7 @@ library Loan {
     /// The purpose of the fields in the case of ordinary loans:
     ///
     /// - firstInstallmentId ------- The ID of the loan.
-    /// - instalmentCount ---------- The total number of installments that always equals zero.
+    /// - installmentCount --------- The total number of installments that always equals zero.
     /// - periodIndex -------------- The period index that matches the preview timestamp.
     /// - totalTrackedBalance ------ The tracked balance of the loan.
     /// - totalOutstandingBalance -- The outstanding balance of the loan.
@@ -142,7 +142,7 @@ library Loan {
     ///    of all installments according to the `ACCURACY_FACTOR` constant.
     struct InstallmentLoanPreview {
         uint256 firstInstallmentId;
-        uint256 instalmentCount;
+        uint256 installmentCount;
         uint256 periodIndex;
         uint256 totalTrackedBalance;
         uint256 totalOutstandingBalance;

--- a/contracts/common/libraries/Loan.sol
+++ b/contracts/common/libraries/Loan.sol
@@ -73,7 +73,10 @@ library Loan {
     /// - instalmentCount ---------- The total number of installments.
     /// - periodIndex -------------- The period index that matches the preview timestamp.
     /// - totalTrackedBalance ------ The total tracked balance of all installments.
-    /// - totalOutstandingBalance -- The total outstanding balance of all installments.
+    /// - totalOutstandingBalance -- The total outstanding balance of all installments
+    /// - totalBorrowAmount -------- The total borrow amount of all installments.
+    /// - totalAddonAmount --------- The total addon amount of all installments.
+    /// - totalRepaidAmount -------- The total repaid amount of all installments.
     ///
     /// The purpose of the fields in the case of ordinary loans:
     ///
@@ -82,6 +85,9 @@ library Loan {
     /// - periodIndex -------------- The period index that matches the preview timestamp.
     /// - totalTrackedBalance ------ The tracked balance of the loan.
     /// - totalOutstandingBalance -- The outstanding balance of the loan.
+    /// - totalBorrowAmount -------- The borrow amount of the loan.
+    /// - totalAddonAmount --------- The addon amount of the loan.
+    /// - totalRepaidAmount -------- The repaid amount of the loan.
     ///
     /// Notes:
     ///
@@ -94,5 +100,8 @@ library Loan {
         uint256 periodIndex;
         uint256 totalTrackedBalance;
         uint256 totalOutstandingBalance;
+        uint256 totalBorrowAmount;
+        uint256 totalAddonAmount;
+        uint256 totalRepaidAmount;
     }
 }

--- a/contracts/common/libraries/Loan.sol
+++ b/contracts/common/libraries/Loan.sol
@@ -83,7 +83,7 @@ library Loan {
     /// - interestRatePrimary ---- The primary interest rate of the loan.
     /// - interestRateSecondary -- The secondary interest rate of the loan.
     /// - firstInstallmentId ----- The ID of the first installment for sub-loans or zero for ordinary loans.
-    /// - installmentCount ------- The total number of installments for sub-loans or zero for ordinary loans.    
+    /// - installmentCount ------- The total number of installments for sub-loans or zero for ordinary loans.
     struct PreviewExtended {
         uint256 periodIndex;
         uint256 trackedBalance;

--- a/contracts/credit-lines/CreditLineConfigurable.sol
+++ b/contracts/credit-lines/CreditLineConfigurable.sol
@@ -348,6 +348,11 @@ contract CreditLineConfigurable is
         return _token;
     }
 
+    /// @inheritdoc ICreditLine
+    function lateFeeRate() external view returns (uint256) {
+        return _config.lateFeeRate;
+    }
+
     /// @dev Calculates the amount of a loan addon (extra charges or fees).
     /// @param amount The initial principal amount of the loan.
     /// @param durationInPeriods The duration of the loan in periods.

--- a/contracts/liquidity-pools/LiquidityPoolAccountable.sol
+++ b/contracts/liquidity-pools/LiquidityPoolAccountable.sol
@@ -79,8 +79,8 @@ contract LiquidityPoolAccountable is
     /// an incorrect value of the `_addonsBalance` variable, or a reversion if `_addonsBalance == 0`.
     error AddonTreasuryAddressZeroingProhibited();
 
-    /// @dev Thrown when the addon treasury has not provided an allowance for the pool contract to transfer its tokens.
-    error AddonTreasuryZeroAllowance();
+    /// @dev Thrown when the addon treasury has not provided an allowance for the lending market to transfer its tokens.
+    error AddonTreasuryZeroAllowanceForMarket();
 
     /// @dev Thrown when the token source balance is insufficient.
     error InsufficientBalance();
@@ -334,8 +334,8 @@ contract LiquidityPoolAccountable is
         if (newTreasury == address(0)) {
             revert AddonTreasuryAddressZeroingProhibited();
         }
-        if (IERC20(_token).allowance(newTreasury, address(this)) == 0) {
-            revert AddonTreasuryZeroAllowance();
+        if (IERC20(_token).allowance(newTreasury, _market) == 0) {
+            revert AddonTreasuryZeroAllowanceForMarket();
         }
         emit AddonTreasuryChanged(newTreasury, oldTreasury);
         _addonTreasury = newTreasury;
@@ -345,11 +345,8 @@ contract LiquidityPoolAccountable is
     ///
     /// See the comments of the {_addonTreasury} storage variable for more details.
     function _collectLoanAddon(uint64 addonAmount) internal {
-        address addonTreasury_ = _addonTreasury;
-        if (addonTreasury_ == address(0)) {
+        if (_addonTreasury == address(0)) {
             _addonsBalance += addonAmount;
-        } else {
-            IERC20(_token).safeTransfer(addonTreasury_, addonAmount);
         }
     }
 
@@ -357,11 +354,8 @@ contract LiquidityPoolAccountable is
     ///
     /// See the comments of the {_addonTreasury} storage variable for more details.
     function _revokeLoanAddon(uint64 addonAmount) internal {
-        address addonTreasury_ = _addonTreasury;
-        if (addonTreasury_ == address(0)) {
+        if (_addonTreasury == address(0)) {
             _addonsBalance -= addonAmount;
-        } else {
-            IERC20(_token).safeTransferFrom(addonTreasury_, address(this), addonAmount);
         }
     }
 }

--- a/contracts/liquidity-pools/LiquidityPoolAccountable.sol
+++ b/contracts/liquidity-pools/LiquidityPoolAccountable.sol
@@ -309,7 +309,7 @@ contract LiquidityPoolAccountable is
         return _token;
     }
 
-    /// @dev ILiquidityPool
+    /// @inheritdoc ILiquidityPool
     function addonTreasury() external view returns (address) {
         return _addonTreasury;
     }

--- a/contracts/mocks/CreditLineMock.sol
+++ b/contracts/mocks/CreditLineMock.sol
@@ -34,6 +34,8 @@ contract CreditLineMock is ICreditLine {
 
     bool private _onAfterLoanRevocationResult;
 
+    uint256 private _lateFeeRate;
+
     // -------------------------------------------- //
     //  ICreditLine functions                       //
     // -------------------------------------------- //
@@ -75,8 +77,8 @@ contract CreditLineMock is ICreditLine {
         return _tokenAddress;
     }
 
-    function lateFeeRate() external pure returns (uint256) {
-        revert Error.NotImplemented();
+    function lateFeeRate() external view returns (uint256) {
+        return _lateFeeRate;
     }
 
     // -------------------------------------------- //
@@ -90,6 +92,10 @@ contract CreditLineMock is ICreditLine {
     function mockLoanTerms(address borrower, uint256 amount, Loan.Terms memory terms) external {
         amount; // To prevent compiler warning about unused variable
         _loanTerms[borrower] = terms;
+    }
+
+    function mockLateFeeRate(uint256 newRate) external {
+        _lateFeeRate = newRate;
     }
 
     function proveCreditLine() external pure {}

--- a/contracts/mocks/CreditLineMock.sol
+++ b/contracts/mocks/CreditLineMock.sol
@@ -75,6 +75,10 @@ contract CreditLineMock is ICreditLine {
         return _tokenAddress;
     }
 
+    function lateFeeRate() external pure returns (uint256) {
+        revert Error.NotImplemented();
+    }
+
     // -------------------------------------------- //
     //  Mock functions                              //
     // -------------------------------------------- //

--- a/contracts/mocks/LendingMarketMock.sol
+++ b/contracts/mocks/LendingMarketMock.sol
@@ -196,6 +196,15 @@ contract LendingMarketMock is ILendingMarket {
         revert Error.NotImplemented();
     }
 
+    function getLoanPreviewExtendedBatch(
+        uint256[] calldata loanIds,
+        uint256 timestamp
+    ) external pure returns (Loan.PreviewExtended[] memory) {
+        loanIds; // To prevent compiler warning about unused variable
+        timestamp; // To prevent compiler warning about unused variable
+        revert Error.NotImplemented();
+    }
+
     function getInstallmentLoanPreview(
         uint256 loanId,
         uint256 timestamp

--- a/contracts/mocks/LendingMarketMock.sol
+++ b/contracts/mocks/LendingMarketMock.sol
@@ -176,22 +176,8 @@ contract LendingMarketMock is ILendingMarket {
         return _loanStates[loanId];
     }
 
-    function getLoanStateBatch(uint256[] calldata loanIds) external pure returns (Loan.State[] memory) {
-        loanIds; // To prevent compiler warning about unused variable
-        revert Error.NotImplemented();
-    }
-
     function getLoanPreview(uint256 loanId, uint256 timestamp) external pure returns (Loan.Preview memory) {
         loanId; // To prevent compiler warning about unused variable
-        timestamp; // To prevent compiler warning about unused variable
-        revert Error.NotImplemented();
-    }
-
-    function getLoanPreviewBatch(
-        uint256[] calldata loanIds,
-        uint256 timestamp
-    ) external pure returns (Loan.Preview[] memory) {
-        loanIds; // To prevent compiler warning about unused variable
         timestamp; // To prevent compiler warning about unused variable
         revert Error.NotImplemented();
     }

--- a/contracts/mocks/LiquidityPoolMock.sol
+++ b/contracts/mocks/LiquidityPoolMock.sol
@@ -33,6 +33,8 @@ contract LiquidityPoolMock is ILiquidityPool {
 
     bool private _onAfterLoanRevocationResult;
 
+    address private _addonTreasury;
+
     // -------------------------------------------- //
     //  ILiquidityPool functions                    //
     // -------------------------------------------- //
@@ -64,6 +66,10 @@ contract LiquidityPoolMock is ILiquidityPool {
         return _tokenAddress;
     }
 
+    function addonTreasury() external view returns (address) {
+        return _addonTreasury;
+    }
+
     // -------------------------------------------- //
     //  Mock functions                              //
     // -------------------------------------------- //
@@ -74,6 +80,10 @@ contract LiquidityPoolMock is ILiquidityPool {
 
     function approveMarket(address _market, address token_) external {
         IERC20(token_).approve(_market, type(uint56).max);
+    }
+
+    function mockAddonTreasury(address newTreasury) external {
+        _addonTreasury = newTreasury;
     }
 
     function proveLiquidityPool() external pure {}

--- a/test-utils/common.ts
+++ b/test-utils/common.ts
@@ -2,12 +2,22 @@ import { expect } from "chai";
 import { network } from "hardhat";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 
-export function checkEquality<T extends Record<string, unknown>>(actualObject: T, expectedObject: T, index?: number) {
+export function checkEquality<T extends Record<string, unknown>>(
+  actualObject: T,
+  expectedObject: T,
+  index?: number,
+  props: {
+    ignoreObjects: boolean;
+  } = { ignoreObjects: false }
+) {
   const indexString = index == null ? "" : ` with index: ${index}`;
   Object.keys(expectedObject).forEach(property => {
     const value = actualObject[property];
     if (typeof value === "undefined" || typeof value === "function") {
       throw Error(`Property "${property}" is not found in the actual object` + indexString);
+    }
+    if (typeof expectedObject[property] === "object" && props.ignoreObjects) {
+      return;
     }
     expect(value).to.eq(
       expectedObject[property],

--- a/test-utils/eth.ts
+++ b/test-utils/eth.ts
@@ -67,3 +67,12 @@ export async function increaseBlockTimestampTo(target: number) {
     throw new Error(`Setting block timestamp for the current blockchain is not supported: ${network.name}`);
   }
 }
+
+export async function getNumberOfEvents(
+  tx: TransactionResponse | Promise<TransactionResponse>,
+  contract: Contract,
+  eventName: string
+): Promise<number> {
+  const topic = contract.filters[eventName].fragment.topicHash;
+  return (await proveTx(tx)).logs.filter(log => log.topics[0] == topic).length;
+}

--- a/test/LendingMarket.base.test.ts
+++ b/test/LendingMarket.base.test.ts
@@ -1763,7 +1763,7 @@ describe("Contract 'LendingMarket': base tests", async () => {
         ).to.be.revertedWithCustomError(marketUnderLender, ERROR_NAME_INVALID_AMOUNT);
       });
 
-      it("The durations in the input array are not an ascending series", async () => {
+      it("The durations in the input array do not correspond to a non-decreasing sequence", async () => {
         const { market, marketUnderLender } = await setUpFixture(deployLendingMarketAndConfigureItForLoan);
         const wrongDurations = [...DURATIONS_IN_PERIODS];
         wrongDurations[INSTALLMENT_COUNT - 1] = wrongDurations[INSTALLMENT_COUNT - 2] - 1;
@@ -2183,41 +2183,43 @@ describe("Contract 'LendingMarket': base tests", async () => {
       });
     });
 
-    it("Is reverted if the contract is paused", async () => {
-      const { market, ordinaryLoan: loan } = await setUpFixture(deployLendingMarketAndTakeLoans);
-      await proveTx(market.pause());
+    describe("Is reverted if", async () => {
+      it("The contract is paused", async () => {
+        const { market, ordinaryLoan: loan } = await setUpFixture(deployLendingMarketAndTakeLoans);
+        await proveTx(market.pause());
 
-      await expect(market.unfreeze(loan.id)).to.be.revertedWithCustomError(market, ERROR_NAME_ENFORCED_PAUSED);
-    });
+        await expect(market.unfreeze(loan.id)).to.be.revertedWithCustomError(market, ERROR_NAME_ENFORCED_PAUSED);
+      });
 
-    it("Is reverted if the loan does not exist", async () => {
-      const { market, ordinaryLoan: loan } = await setUpFixture(deployLendingMarketAndTakeLoans);
-      const wrongLoanId = loan.id + 123;
+      it("The loan does not exist", async () => {
+        const { market, ordinaryLoan: loan } = await setUpFixture(deployLendingMarketAndTakeLoans);
+        const wrongLoanId = loan.id + 123;
 
-      await expect(market.unfreeze(wrongLoanId))
-        .to.be.revertedWithCustomError(market, ERROR_NAME_LOAN_NOT_EXIST);
-    });
+        await expect(market.unfreeze(wrongLoanId))
+          .to.be.revertedWithCustomError(market, ERROR_NAME_LOAN_NOT_EXIST);
+      });
 
-    it("Is reverted if the loan is already repaid", async () => {
-      const { market, ordinaryLoan: loan } = await setUpFixture(deployLendingMarketAndTakeLoans);
-      await proveTx(connect(market, borrower).repayLoan(loan.id, FULL_REPAYMENT_AMOUNT));
+      it("The loan is already repaid", async () => {
+        const { market, ordinaryLoan: loan } = await setUpFixture(deployLendingMarketAndTakeLoans);
+        await proveTx(connect(market, borrower).repayLoan(loan.id, FULL_REPAYMENT_AMOUNT));
 
-      await expect(connect(market, lender).unfreeze(loan.id))
-        .to.be.revertedWithCustomError(market, ERROR_NAME_LOAN_ALREADY_REPAID);
-    });
+        await expect(connect(market, lender).unfreeze(loan.id))
+          .to.be.revertedWithCustomError(market, ERROR_NAME_LOAN_ALREADY_REPAID);
+      });
 
-    it("Is reverted if the caller is not the lender or an alias", async () => {
-      const { market, ordinaryLoan: loan } = await setUpFixture(deployLendingMarketAndTakeLoans);
+      it("The caller is not the lender or an alias", async () => {
+        const { market, ordinaryLoan: loan } = await setUpFixture(deployLendingMarketAndTakeLoans);
 
-      await expect(connect(market, attacker).unfreeze(loan.id))
-        .to.be.revertedWithCustomError(market, ERROR_NAME_UNAUTHORIZED);
-    });
+        await expect(connect(market, attacker).unfreeze(loan.id))
+          .to.be.revertedWithCustomError(market, ERROR_NAME_UNAUTHORIZED);
+      });
 
-    it("Is reverted if the loan is not frozen", async () => {
-      const { marketUnderLender, ordinaryLoan: loan } = await setUpFixture(deployLendingMarketAndTakeLoans);
+      it("The loan is not frozen", async () => {
+        const { marketUnderLender, ordinaryLoan: loan } = await setUpFixture(deployLendingMarketAndTakeLoans);
 
-      await expect(marketUnderLender.unfreeze(loan.id))
-        .to.be.revertedWithCustomError(marketUnderLender, ERROR_NAME_LOAN_NOT_FROZEN);
+        await expect(marketUnderLender.unfreeze(loan.id))
+          .to.be.revertedWithCustomError(marketUnderLender, ERROR_NAME_LOAN_NOT_FROZEN);
+      });
     });
   });
 

--- a/test/LendingMarket.base.test.ts
+++ b/test/LendingMarket.base.test.ts
@@ -46,7 +46,7 @@ interface LoanState {
   trackedTimestamp: number;
   freezeTimestamp: number;
   firstInstallmentId: number;
-  instalmentCount: number;
+  installmentCount: number;
   lateFeeAmount: number;
 
   [key: string]: string | number; // Index signature
@@ -91,7 +91,7 @@ interface LoanPreviewExtended {
 
 interface InstallmentLoanPreview {
   firstInstallmentId: number;
-  instalmentCount: number;
+  installmentCount: number;
   periodIndex: number;
   totalTrackedBalance: number;
   totalOutstandingBalance: number;
@@ -223,7 +223,7 @@ const defaultLoanState: LoanState = {
   trackedTimestamp: 0,
   freezeTimestamp: 0,
   firstInstallmentId: 0,
-  instalmentCount: 0,
+  installmentCount: 0,
   lateFeeAmount: 0
 };
 
@@ -403,7 +403,7 @@ describe("Contract 'LendingMarket': base tests", async () => {
         trackedBalance: props.borrowAmounts[i] + props.addonAmounts[i],
         trackedTimestamp: timestampWithOffset,
         firstInstallmentId: props.firstInstallmentId,
-        instalmentCount: props.borrowAmounts.length
+        installmentCount: props.borrowAmounts.length
       };
       const loanConfig: LoanConfig = {
         ...defaultLoanConfig,
@@ -518,7 +518,7 @@ describe("Contract 'LendingMarket': base tests", async () => {
       interestRatePrimary: loan.state.interestRatePrimary,
       interestRateSecondary: loan.state.interestRateSecondary,
       firstInstallmentId: loan.state.firstInstallmentId,
-      installmentCount: loan.state.instalmentCount
+      installmentCount: loan.state.installmentCount
     };
   }
 
@@ -526,7 +526,7 @@ describe("Contract 'LendingMarket': base tests", async () => {
     const loanPreviews: LoanPreviewExtended[] = loans.map(loan => determineLoanPreviewExtended(loan, timestamp));
     return {
       firstInstallmentId: loans[0].state.firstInstallmentId,
-      instalmentCount: loans[0].state.instalmentCount,
+      installmentCount: loans[0].state.installmentCount,
       periodIndex: loanPreviews[0].periodIndex,
       totalTrackedBalance: loanPreviews
         .map(preview => preview.trackedBalance)

--- a/test/LendingMarket.base.test.ts
+++ b/test/LendingMarket.base.test.ts
@@ -204,7 +204,7 @@ const DURATIONS_IN_PERIODS: number[] = [0, DURATION_IN_PERIODS / 2, DURATION_IN_
 
 const EXPECTED_VERSION: Version = {
   major: 1,
-  minor: 4,
+  minor: 5,
   patch: 0
 };
 

--- a/test/LendingMarket.complex.test.ts
+++ b/test/LendingMarket.complex.test.ts
@@ -241,7 +241,7 @@ describe("Contract 'LendingMarket': complex tests", async () => {
     await proveTx(lendingMarket.createProgram(creditLineAddress, liquidityPoolAddress));
 
     // Configure addon treasure
-    await proveTx(connect(token, addonTreasury).approve(liquidityPoolAddress, MAX_ALLOWANCE));
+    await proveTx(connect(token, addonTreasury).approve(lendingMarketAddress, MAX_ALLOWANCE));
     await proveTx(liquidityPool.setAddonTreasury(addonTreasury.address));
 
     // Mint token

--- a/test/LendingMarket.complex.test.ts
+++ b/test/LendingMarket.complex.test.ts
@@ -56,6 +56,7 @@ interface TestScenario {
   durationInPeriods: number;
   interestRatePrimary: number;
   interestRateSecondary: number;
+  lateFeeRate: number;
   iterationStep: number;
   relativePrecision: number;
   repaymentAmounts: number[];
@@ -90,6 +91,7 @@ interface CreditLineConfig {
   maxAddonFixedRate: number;
   minAddonPeriodRate: number;
   maxAddonPeriodRate: number;
+  lateFeeRate: number;
 
   [key: string]: number; // Index signature
 }
@@ -115,6 +117,7 @@ const testScenarioDefault: TestScenario = {
   durationInPeriods: 180,
   interestRatePrimary: 0,
   interestRateSecondary: 0,
+  lateFeeRate: 20_000_000, // 2 %
   iterationStep: 30,
   relativePrecision: 1e-7, // 0.00001% difference
   repaymentAmounts: [],
@@ -300,7 +303,8 @@ describe("Contract 'LendingMarket': complex tests", async () => {
       minAddonFixedRate: 0,
       maxAddonFixedRate: 0,
       minAddonPeriodRate: 0,
-      maxAddonPeriodRate: 0
+      maxAddonPeriodRate: 0,
+      lateFeeRate: scenario.lateFeeRate
     };
   }
 
@@ -534,7 +538,7 @@ describe("Contract 'LendingMarket': complex tests", async () => {
         // The numbers below are taken form spreadsheet:
         // https://docs.google.com/spreadsheets/d/148elvx9Yd0QuaDtc7AkaelIn3t5rvZCx5iG2ceVfpe8
         1085060000, 992900000, 892900000, 968850000, 1051260000, 956220000,
-        888040000, 811020000, 641020000, 471020000, 340010000, 192020000
+        905800000, 831090000, 661090000, 491090000, 362670000, 217620000
         /* eslint-enable @stylistic/array-element-newline*/
       ];
 
@@ -561,7 +565,7 @@ describe("Contract 'LendingMarket': complex tests", async () => {
 
       const repaymentAmounts: number[] = Array(12).fill(0); // 0 BRLC
       repaymentAmounts[10] = 1500_000_000; // 1500 BRLC
-      repaymentAmounts[11] = 962_030_000; // 962.03 BRLC
+      repaymentAmounts[11] = 1_015_150_000; // 1015.15 BRLC
 
       const frozenStepIndexes: number[] = [2, 3];
 
@@ -570,7 +574,7 @@ describe("Contract 'LendingMarket': complex tests", async () => {
         // The numbers below are taken form spreadsheet:
         // https://docs.google.com/spreadsheets/d/148elvx9Yd0QuaDtc7AkaelIn3t5rvZCx5iG2ceVfpe8
         1085060000, 1177360000, 1177360000, 1177360000, 1277510000, 1386180000,
-        1504090000, 1632030000, 1843380000, 2082090000, 2351730000, 962030000
+        1504090000, 1632030000, 1880240000, 2123740000, 2398760000, 1015150000
         /* eslint-enable @stylistic/array-element-newline*/
       ];
 
@@ -603,9 +607,9 @@ describe("Contract 'LendingMarket': complex tests", async () => {
         // The numbers below are taken form spreadsheet:
         // https://docs.google.com/spreadsheets/d/148elvx9Yd0QuaDtc7AkaelIn3t5rvZCx5iG2ceVfpe8
         1134642760000, 1287300730000, 1460512990000, 1657047030000, 1880042950000, 2133063660000,
-        2538189960000, 3020283270000, 3593965980000, 4276638520000, 5089007060000, 6055711610000,
-        7206073340000, 8574983950000, 10203963970000, 12142422090000, 14449153800000, 17194124750000,
-        20460592820000, 24347633470000, 28973144780000, 34477423440000, 41027420090000, 48821803090000
+        2588953760000, 3080691310000, 3665850520000, 4362179870000, 5190799790000, 6176843200000,
+        7350217850000, 8746513440000, 10408081090000, 12385317940000, 14738195680000, 17538079600000,
+        20869893150000, 24834693800000, 29552738180000, 35167129580000, 41848158500000, 49798467640000
         /* eslint-enable @stylistic/array-element-newline*/
       ];
 
@@ -631,7 +635,7 @@ describe("Contract 'LendingMarket': complex tests", async () => {
       const interestRateSecondary = 499_635; // 20 % annual
 
       const repaymentAmounts: number[] = Array(12).fill(90_000); // 0.09 BRLC
-      repaymentAmounts[repaymentAmounts.length - 1] = 70_000; // 0.07 BRLC
+      repaymentAmounts[repaymentAmounts.length - 1] = 80_000; // 0.08 BRLC
 
       const frozenStepIndexes: number[] = [];
 
@@ -640,7 +644,7 @@ describe("Contract 'LendingMarket': complex tests", async () => {
         // The numbers below are taken form spreadsheet:
         // https://docs.google.com/spreadsheets/d/148elvx9Yd0QuaDtc7AkaelIn3t5rvZCx5iG2ceVfpe8
         1010000, 930000, 840000, 760000, 670000, 590000,
-        500000, 420000, 340000, 250000, 160000, 70000
+        520000, 430000, 350000, 260000, 170000, 80000
         /* eslint-enable @stylistic/array-element-newline*/
       ];
 

--- a/test/credit-lines/CreditLineConfigurable.test.ts
+++ b/test/credit-lines/CreditLineConfigurable.test.ts
@@ -209,7 +209,7 @@ const LATE_FEE_RATE = 987654321n;
 
 const EXPECTED_VERSION: Version = {
   major: 1,
-  minor: 4,
+  minor: 5,
   patch: 0
 };
 

--- a/test/credit-lines/CreditLineConfigurable.test.ts
+++ b/test/credit-lines/CreditLineConfigurable.test.ts
@@ -24,6 +24,7 @@ interface CreditLineConfig {
   maxAddonFixedRate: bigint;
   minAddonPeriodRate: bigint;
   maxAddonPeriodRate: bigint;
+  lateFeeRate: bigint;
 
   [key: string]: bigint; // Index signature
 }
@@ -78,6 +79,7 @@ interface LoanState {
   freezeTimestamp: bigint;
   firstInstallmentId: bigint;
   instalmentCount: bigint;
+  lateFeeAmount: bigint;
 }
 
 interface Version {
@@ -112,7 +114,8 @@ const defaultCreditLineConfig: CreditLineConfig = {
   minAddonFixedRate: 0n,
   maxAddonFixedRate: 0n,
   minAddonPeriodRate: 0n,
-  maxAddonPeriodRate: 0n
+  maxAddonPeriodRate: 0n,
+  lateFeeRate: 0n
 };
 
 const defaultBorrowerConfig: BorrowerConfig = {
@@ -150,7 +153,8 @@ const defaultLoanState: LoanState = {
   trackedTimestamp: 0n,
   freezeTimestamp: 0n,
   firstInstallmentId: 0n,
-  instalmentCount: 0n
+  instalmentCount: 0n,
+  lateFeeAmount: 0n
 };
 
 const ERROR_NAME_ACCESS_CONTROL_UNAUTHORIZED = "AccessControlUnauthorizedAccount";
@@ -201,6 +205,7 @@ const BORROW_AMOUNT = 1234_567_890n;
 const LOAN_ID = 123n;
 const ADDON_AMOUNT = 123456789n;
 const REPAY_AMOUNT = 12345678n;
+const LATE_FEE_RATE = 987654321n;
 
 const EXPECTED_VERSION: Version = {
   major: 1,
@@ -304,7 +309,8 @@ describe("Contract 'CreditLineConfigurable'", async () => {
       minAddonFixedRate: MIN_ADDON_FIXED_RATE,
       maxAddonFixedRate: MAX_ADDON_FIXED_RATE,
       minAddonPeriodRate: MIN_ADDON_PERIOD_RATE,
-      maxAddonPeriodRate: MAX_ADDON_PERIOD_RATE
+      maxAddonPeriodRate: MAX_ADDON_PERIOD_RATE,
+      lateFeeRate: LATE_FEE_RATE
     };
   }
 
@@ -1174,6 +1180,15 @@ describe("Contract 'CreditLineConfigurable'", async () => {
         creditLine,
         ERROR_NAME_LIMIT_VIOLATION_ON_TOTAL_ACTIVE_LOAN_AMOUNT
       ).withArgs(borrowerState.totalActiveLoanAmount + BigInt(BORROW_AMOUNT));
+    });
+  });
+
+  describe("Function 'lateFeeRate()'", async () => {
+    it("Returns the expected value", async () => {
+      const { creditLine } = await setUpFixture(deployAndConfigureContractsWithBorrower);
+
+      const actualValue = await creditLine.lateFeeRate();
+      expect(actualValue).to.equal(LATE_FEE_RATE);
     });
   });
 

--- a/test/credit-lines/CreditLineConfigurable.test.ts
+++ b/test/credit-lines/CreditLineConfigurable.test.ts
@@ -78,7 +78,7 @@ interface LoanState {
   trackedTimestamp: bigint;
   freezeTimestamp: bigint;
   firstInstallmentId: bigint;
-  instalmentCount: bigint;
+  installmentCount: bigint;
   lateFeeAmount: bigint;
 }
 
@@ -153,7 +153,7 @@ const defaultLoanState: LoanState = {
   trackedTimestamp: 0n,
   freezeTimestamp: 0n,
   firstInstallmentId: 0n,
-  instalmentCount: 0n,
+  installmentCount: 0n,
   lateFeeAmount: 0n
 };
 

--- a/test/liquidity-pools/LiquidityPoolAccountable.test.ts
+++ b/test/liquidity-pools/LiquidityPoolAccountable.test.ts
@@ -20,7 +20,7 @@ interface LoanState {
   trackedTimestamp: bigint;
   freezeTimestamp: bigint;
   firstInstallmentId: bigint;
-  instalmentCount: bigint;
+  installmentCount: bigint;
   lateFeeAmount: bigint;
 }
 
@@ -94,7 +94,7 @@ const defaultLoanState: LoanState = {
   trackedTimestamp: 0n,
   freezeTimestamp: 0n,
   firstInstallmentId: 0n,
-  instalmentCount: 0n,
+  installmentCount: 0n,
   lateFeeAmount: 0n
 };
 

--- a/test/liquidity-pools/LiquidityPoolAccountable.test.ts
+++ b/test/liquidity-pools/LiquidityPoolAccountable.test.ts
@@ -33,7 +33,7 @@ interface Version {
 }
 
 const ERROR_NAME_ADDON_TREASURY_ADDRESS_ZEROING_PROHIBITED = "AddonTreasuryAddressZeroingProhibited";
-const ERROR_NAME_ADDON_TREASURY_ZERO_ALLOWANCE = "AddonTreasuryZeroAllowance";
+const ERROR_NAME_ADDON_TREASURY_ZERO_ALLOWANCE_FOR_MARKET = "AddonTreasuryZeroAllowanceForMarket";
 const ERROR_NAME_ALREADY_CONFIGURED = "AlreadyConfigured";
 const ERROR_NAME_ALREADY_INITIALIZED = "InvalidInitialization";
 const ERROR_NAME_ARRAY_LENGTH_MISMATCH = "ArrayLengthMismatch";
@@ -150,7 +150,7 @@ describe("Contract 'LiquidityPoolAccountable'", async () => {
     liquidityPool = connect(liquidityPool, lender); // Explicitly specifying the initial account
 
     await proveTx(connect(token, lender).approve(getAddress(liquidityPool), MAX_ALLOWANCE));
-    await proveTx(connect(token, addonTreasury).approve(getAddress(liquidityPool), MAX_ALLOWANCE));
+    await proveTx(connect(token, addonTreasury).approve(getAddress(market), MAX_ALLOWANCE));
     return { liquidityPool };
   }
 
@@ -261,7 +261,7 @@ describe("Contract 'LiquidityPoolAccountable'", async () => {
     it("Executes as expected and emits the correct event", async () => {
       const { liquidityPool } = await setUpFixture(deployLiquidityPool);
       const allowance = 1; // This allowance should be enough
-      await proveTx(connect(token, addonTreasury).approve(getAddress(liquidityPool), allowance));
+      await proveTx(connect(token, addonTreasury).approve(getAddress(market), allowance));
 
       await expect(liquidityPool.setAddonTreasury(addonTreasury.address))
         .to.emit(liquidityPool, EVENT_NAME_ADDON_TREASURY_CHANGED)
@@ -308,10 +308,10 @@ describe("Contract 'LiquidityPoolAccountable'", async () => {
 
     it("Is reverted if the addon treasury has not provided an allowance for the pool", async () => {
       const { liquidityPool } = await setUpFixture(deployLiquidityPool);
-      await proveTx(connect(token, addonTreasury).approve(getAddress(liquidityPool), ZERO_ALLOWANCE));
+      await proveTx(connect(token, addonTreasury).approve(getAddress(market), ZERO_ALLOWANCE));
 
       await expect(liquidityPool.setAddonTreasury(addonTreasury.address))
-        .to.be.revertedWithCustomError(liquidityPool, ERROR_NAME_ADDON_TREASURY_ZERO_ALLOWANCE);
+        .to.be.revertedWithCustomError(liquidityPool, ERROR_NAME_ADDON_TREASURY_ZERO_ALLOWANCE_FOR_MARKET);
     });
   });
 
@@ -657,18 +657,8 @@ describe("Contract 'LiquidityPoolAccountable'", async () => {
       expect(actualBalances[0]).to.eq(DEPOSIT_AMOUNT - BORROW_AMOUNT - ADDON_AMOUNT);
       if (addonTreasuryAddress === ZERO_ADDRESS) {
         expect(actualBalances[1]).to.eq(ADDON_AMOUNT);
-        await expect(tx).to.changeTokenBalances(
-          token,
-          [liquidityPool, addonTreasury],
-          [0, 0]
-        );
       } else {
         expect(actualBalances[1]).to.eq(0);
-        await expect(tx).to.changeTokenBalances(
-          token,
-          [liquidityPool, addonTreasury],
-          [-ADDON_AMOUNT, ADDON_AMOUNT]
-        );
       }
     }
 
@@ -789,19 +779,9 @@ describe("Contract 'LiquidityPoolAccountable'", async () => {
       const actualBalancesAfter: bigint[] = await liquidityPool.getBalances();
 
       if (addonTreasuryAddress === ZERO_ADDRESS) {
-        await expect(tx).to.changeTokenBalances(
-          token,
-          [liquidityPool, addonTreasury],
-          [0, 0]
-        );
         expect(actualBalancesAfter[0]).to.eq(DEPOSIT_AMOUNT);
         expect(actualBalancesAfter[1]).to.eq(0n);
       } else {
-        await expect(tx).to.changeTokenBalances(
-          token,
-          [liquidityPool, addonTreasury],
-          [ADDON_AMOUNT, -ADDON_AMOUNT]
-        );
         expect(actualBalancesAfter[0]).to.eq(DEPOSIT_AMOUNT);
         expect(actualBalancesAfter[1]).to.eq(actualBalancesBefore[1]);
       }

--- a/test/liquidity-pools/LiquidityPoolAccountable.test.ts
+++ b/test/liquidity-pools/LiquidityPoolAccountable.test.ts
@@ -21,6 +21,7 @@ interface LoanState {
   freezeTimestamp: bigint;
   firstInstallmentId: bigint;
   instalmentCount: bigint;
+  lateFeeAmount: bigint;
 }
 
 interface Version {
@@ -93,7 +94,8 @@ const defaultLoanState: LoanState = {
   trackedTimestamp: 0n,
   freezeTimestamp: 0n,
   firstInstallmentId: 0n,
-  instalmentCount: 0n
+  instalmentCount: 0n,
+  lateFeeAmount: 0n
 };
 
 describe("Contract 'LiquidityPoolAccountable'", async () => {

--- a/test/liquidity-pools/LiquidityPoolAccountable.test.ts
+++ b/test/liquidity-pools/LiquidityPoolAccountable.test.ts
@@ -75,7 +75,7 @@ const AUTO_REPAY_LOAN_IDS = [123n, 234n, 345n, 123n];
 const AUTO_REPAY_AMOUNTS = [10_123_456n, 1n, maxUintForBits(256), 0n];
 const EXPECTED_VERSION: Version = {
   major: 1,
-  minor: 4,
+  minor: 5,
   patch: 0
 };
 

--- a/test/mocks/LendingMarketMock.test.ts
+++ b/test/mocks/LendingMarketMock.test.ts
@@ -203,6 +203,13 @@ describe("Contract 'LendingMarketMock'", async () => {
         .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
     });
 
+    it("Function 'getLoanPreviewExtendedBatch()'", async () => {
+      const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
+
+      await expect(lendingMarket.getLoanPreviewExtendedBatch([MOCK_LOAN_ID], 0))
+        .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
+    });
+
     it("Function 'getInstallmentLoanPreview()'", async () => {
       const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
 

--- a/test/mocks/LendingMarketMock.test.ts
+++ b/test/mocks/LendingMarketMock.test.ts
@@ -182,24 +182,10 @@ describe("Contract 'LendingMarketMock'", async () => {
         .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
     });
 
-    it("Function 'getLoanStateBatch()'", async () => {
-      const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
-
-      await expect(lendingMarket.getLoanStateBatch([MOCK_LOAN_ID]))
-        .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
-    });
-
     it("Function 'getLoanPreview()'", async () => {
       const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
 
       await expect(lendingMarket.getLoanPreview(MOCK_LOAN_ID, 0))
-        .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
-    });
-
-    it("Function 'getLoanPreviewBatch()'", async () => {
-      const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
-
-      await expect(lendingMarket.getLoanPreviewBatch([MOCK_LOAN_ID], 0))
         .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
     });
 


### PR DESCRIPTION
## Main changes

1. The late fee imposing feature has been introduced.  Key points of the feature:
    * a. The fee is charged by the lending market contract if the payment is overdue for one period (day) or more.
    * b. The fee amount is returned by the new preview functions in structures `PreviewExtended` and `InstallmentLoanPreview` if the requested preview timestamp is after the due date of a loan.
    * c. The fee amount is stored in the `Loan.State` structure if:
        * i. a repayment happen after the loan due date;
        * ii. freezing operation with the following unfreezing one are executed after the loan due date.
    * d. The late fee rate is configured on the credit line contract through the `configureCreditLine()` function. The appropriate field has been appended to the `CreditLineConfig` structure.

2. Token transfers for sub-loans during installment loan taking or revocation have been consolidated. Previously, each sub-loan of an installment loan generate its own transfers. Currently, only combined transfers are carried out: one for transferring tokens from the liquidity pool to the borrower, the second for transferring tokens from the liquidity pool to the addon treasury (if the treasury address is configured on the pool).

3. The management of the addon amount transfers has been moved from the liquidity pool smart contract to the lending market one.

4. A new loan preview function named `getLoanPreviewExtendedBatch()` has been introduced. The function returns an array of the `PreviewExtended` structures for the requested array of loan IDs and the preview timestamp.

    <details>
    
    <summary>The new function definition </summary>
    
    ```solidity
    /// @dev Gets the loan extended preview at a specific timestamp for a batch of ordinary loans or sub-loans.
    /// @param loanIds The unique identifiers of the loans to check.
    /// @param timestamp The timestamp to get the loan preview for. If 0, the current timestamp is used.
    /// @return The extended previews of the loans (see the `Loan.PreviewExtended` struct).
    function getLoanPreviewExtendedBatch(
        uint256[] calldata loanIds,
        uint256 timestamp
    ) external view returns (Loan.PreviewExtended[] memory);
    ```
    
    </details>
    
    <details>
    
    <summary>The new structure definition </summary>
    
    ```solidity
    /// @dev A struct that defines the extended preview of a loan.
    ///
    /// Fields:
    /// - periodIndex ------------ The period index that matches the preview timestamp.
    /// - trackedBalance --------- The tracked balance of the loan at the previewed period.
    /// - outstandingBalance ----- The outstanding balance of the loan at the previewed period.
    /// - borrowAmount ----------- The borrow amount of the loan at the previewed period.
    /// - addonAmount ------------ The addon amount of the loan at the previewed period.
    /// - repaidAmount ----------- The repaid amount of the loan at the previewed period.
    /// - lateFeeAmount ---------- The late fee amount of the loan at the previewed period.
    /// - programId -------------- The program ID of the loan.
    /// - borrower --------------- The borrower of the loan.
    /// - previewTimestamp ------- The preview timestamp.
    /// - startTimestamp --------- The start timestamp of the loan.
    /// - trackedTimestamp ------- The tracked timestamp of the loan.
    /// - freezeTimestamp -------- The freeze timestamp of the loan.
    /// - durationInPeriods ------ The duration in periods of the loan.
    /// - interestRatePrimary ---- The primary interest rate of the loan.
    /// - interestRateSecondary -- The secondary interest rate of the loan.
    /// - firstInstallmentId ----- The ID of the first installment for sub-loans or zero for ordinary loans.
    /// - installmentCount ------- The total number of installments for sub-loans or zero for ordinary loans.
    struct PreviewExtended {
        uint256 periodIndex;
        uint256 trackedBalance;
        uint256 outstandingBalance;
        uint256 borrowAmount;
        uint256 addonAmount;
        uint256 repaidAmount;
        uint256 lateFeeAmount;
        uint256 programId;
        address borrower;
        uint256 previewTimestamp;
        uint256 startTimestamp;
        uint256 trackedTimestamp;
        uint256 freezeTimestamp;
        uint256 durationInPeriods;
        uint256 interestRatePrimary;
        uint256 interestRateSecondary;
        uint256 firstInstallmentId;
        uint256 installmentCount;
    }
    ```
    
    </details>

5. The `InstallmentLoanPreview` structure returned by the `getInstallmentLoanPreview()` function has been extended with new 5 fields at the end: `totalBorrowAmount`; `totalAddonAmount`; `totalRepaidAmount`; `totalLateFeeAmount`; `installmentPreviews`.

    <details>

    <summary>The new structure definition </summary>
    
    ```solidity
    /// @dev A struct that defines the preview of an installment loan.
    ///
    /// The structure can be returned for both ordinary and installment loans.
    ///
    /// The purpose of the fields in the case of installment loans:
    ///
    /// - firstInstallmentId ------- The first installment ID.
    /// - installmentCount --------- The total number of installments.
    /// - periodIndex -------------- The period index that matches the preview timestamp.
    /// - totalTrackedBalance ------ The total tracked balance of all installments.
    /// - totalOutstandingBalance -- The total outstanding balance of all installments
    /// - totalBorrowAmount -------- The total borrow amount of all installments.
    /// - totalAddonAmount --------- The total addon amount of all installments.
    /// - totalRepaidAmount -------- The total repaid amount of all installments.
    /// - totalLateFeeAmount ------- The total late fee amount of all installments.
    /// - installmentPreviews ------ The extended previews of all installments.
    ///
    /// The purpose of the fields in the case of ordinary loans:
    ///
    /// - firstInstallmentId ------- The ID of the loan.
    /// - installmentCount --------- The total number of installments that always equals zero.
    /// - periodIndex -------------- The period index that matches the preview timestamp.
    /// - totalTrackedBalance ------ The tracked balance of the loan.
    /// - totalOutstandingBalance -- The outstanding balance of the loan.
    /// - totalBorrowAmount -------- The borrow amount of the loan.
    /// - totalAddonAmount --------- The addon amount of the loan.
    /// - totalRepaidAmount -------- The repaid amount of the loan.
    /// - totalLateFeeAmount ------- The late fee amount of the loan.
    /// - installmentPreviews ------ The extended preview of the loan as a single item array.

    /// Notes:
    ///
    /// 1. The `totalTrackedBalance` fields calculates as the sum of tracked balances of all installments.
    /// 2. The `totalOutstandingBalance` fields calculates as the sum of rounded tracked balances
    ///    of all installments according to the `ACCURACY_FACTOR` constant.
    struct InstallmentLoanPreview {
        uint256 firstInstallmentId;
        uint256 installmentCount;
        uint256 periodIndex;
        uint256 totalTrackedBalance;
        uint256 totalOutstandingBalance;
        uint256 totalBorrowAmount;
        uint256 totalAddonAmount;
        uint256 totalRepaidAmount;
        uint256 totalLateFeeAmount;
        PreviewExtended[] installmentPreviews;
    }
    ```
    
    </details>

6. The following viewing functions have been removed as not very useful and to reduce the size of the lending market smart-contract:
    * a. `getLoanStateBatch()`.
    * b. `getLoanPreviewBatch()`.

7. In the `Loan.State` and `Loan.InstallmentLoanPreview` structures a flied has been renamed: `instalmentCount` (single `l`) => `installmentCount` (double `l`).

## Versioning

The new version of the smart-contracts is `1.5.0`.

## Test Coverage

The new function and logic are fully covered by tests.

<details>

<summary>Test coverage details</summary>

| File                                    |  % Stmts | % Branch |  % Funcs |  % Lines |
|-----------------------------------------|---------:|---------:|---------:|---------:|
| contracts/                              |   100.00 |    99.04 |   100.00 |   100.00 |
| ├─ LendingMarket.sol                    |   100.00 |    99.03 |   100.00 |   100.00 |
| ├─ LendingMarketStorage.sol             |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketUUPS.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/                       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeable.sol      |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/interfaces/            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICreditLineConfigurable.sol          |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILiquidityPoolAccountable.sol        |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/interfaces/core/       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICreditLine.sol                      |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILendingMarket.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILiquidityPool.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/libraries/             |   100.00 |    70.00 |   100.00 |    100.00 |
| ├─ ABDKMath64x64.sol                    |   100.00 |    65.91 |   100.00 |    100.00 |
| ├─ Constants.sol                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Error.sol                            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ InterestMath.sol                     |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Loan.sol                             |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Round.sol                            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ SafeCast.sol                         |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/credit-lines/                 |   100.00 |    97.37 |   100.00 |   100.00 |
| ├─ CreditLineConfigurable.sol           |   100.00 |    97.32 |   100.00 |   100.00 |
| ├─ CreditLineConfigurableUUPS.sol       |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/liquidity-pools/              |   100.00 |    97.22 |   100.00 |   100.00 |
| ├─ LiquidityPoolAccountable.sol         |   100.00 |    97.14 |   100.00 |   100.00 |
| ├─ LiquidityPoolAccountableUUPS.sol     |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/mocks/                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeableMock.sol  |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineMock.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ERC20Mock.sol                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketMock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPoolMock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/testables/                    |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineConfigurableTestable.sol   |   100.00 |   100.00 |   100.00 |   100.00 |
|-----------------------------------------|----------|----------|----------|----------|
| All files                               |   100.00 |    95.22 |   100.00 |    100.00 |
|-----------------------------------------|----------|----------|----------|----------|
</details>

