### PR TITLE
feat: new repayment function

### DIFF
--- a/contracts/common/Versionable.sol
+++ b/contracts/common/Versionable.sol
@@ -16,6 +16,6 @@ abstract contract Versionable is IVersionable {
      * @inheritdoc IVersionable
      */
     function $__VERSION() external pure returns (Version memory) {
-        return Version(1, 5, 0);
+        return Version(1, 6, 0);
     }
 }

--- a/contracts/common/interfaces/core/ILendingMarket.sol
+++ b/contracts/common/interfaces/core/ILendingMarket.sol
@@ -61,7 +61,7 @@ interface ILendingMarket {
 
     /// @dev Emitted when a loan is repaid (fully or partially).
     /// @param loanId The unique identifier of the loan.
-    /// @param repayer The address of the repayer (borrower or third-party).
+    /// @param repayer The address of the token source for the repayment (borrower or third-party).
     /// @param borrower The address of the borrower of the loan.
     /// @param repayAmount The amount of the repayment.
     /// @param outstandingBalance The outstanding balance of the loan after the repayment.
@@ -220,6 +220,19 @@ interface ILendingMarket {
     /// @param loanId The unique identifier of the loan to repay.
     /// @param repayAmount The amount to repay or `type(uint256).max` to repay the remaining balance of the loan.
     function repayLoan(uint256 loanId, uint256 repayAmount) external;
+
+    /// @dev Repays a batch of loans.
+    ///
+    /// Can be called only by an account with a special role.
+    ///
+    /// @param loanIds The unique identifiers of the loans to repay.
+    /// @param repaymentAmounts The amounts to repay for each loan.
+    /// @param repayer The address of the token source for the repayments (borrower or third-party).
+    function repayLoanForBatch(
+        uint256[] calldata loanIds,
+        uint256[] calldata repaymentAmounts,
+        address repayer
+    ) external;
 
     // -------------------------------------------- //
     //  Lender functions                            //

--- a/contracts/mocks/LendingMarketMock.sol
+++ b/contracts/mocks/LendingMarketMock.sol
@@ -103,6 +103,17 @@ contract LendingMarketMock is ILendingMarket {
         emit RepayLoanCalled(loanId, repayAmount, repaymentCounter);
     }
 
+    function repayLoanForBatch(
+        uint256[] calldata loanIds,
+        uint256[] calldata repaymentAmounts,
+        address repayer
+    ) external pure {
+        loanIds; // To prevent compiler warning about unused variable
+        repaymentAmounts; // To prevent compiler warning about unused variable
+        repayer; // To prevent compiler warning about unused variable
+        revert Error.NotImplemented();
+    }
+
     function freeze(uint256 loanId) external pure {
         loanId; // To prevent compiler warning about unused variable
         revert Error.NotImplemented();

--- a/test/LendingMarket.base.test.ts
+++ b/test/LendingMarket.base.test.ts
@@ -204,7 +204,7 @@ const DURATIONS_IN_PERIODS: number[] = [0, DURATION_IN_PERIODS / 2, DURATION_IN_
 
 const EXPECTED_VERSION: Version = {
   major: 1,
-  minor: 5,
+  minor: 6,
   patch: 0
 };
 

--- a/test/LendingMarket.base.test.ts
+++ b/test/LendingMarket.base.test.ts
@@ -2018,6 +2018,271 @@ describe("Contract 'LendingMarket': base tests", async () => {
     });
   });
 
+  describe("Function 'repayLoanForBatch()'", async () => {
+    async function executeAndCheck(
+      fixture: Fixture,
+      currentLoans: Loan[],
+      repaymentAmounts: (number | bigint)[],
+      payerKind: PayerKind
+    ): Promise<Loan[]> {
+      const expectedLoans: Loan[] = currentLoans.map(loan => clone(loan));
+      const loanIds: number[] = expectedLoans.map(loan => loan.id);
+      const { marketUnderLender } = fixture;
+      let tx: Promise<TransactionResponse>;
+      let payer: HardhatEthersSigner;
+
+      switch (payerKind) {
+        case PayerKind.Borrower:
+          payer = borrower;
+          // Be sure the function can be called by an alias
+          connect(marketUnderLender, alias).repayLoanForBatch.staticCall(loanIds, repaymentAmounts, payer.address);
+          tx = marketUnderLender.repayLoanForBatch(loanIds, repaymentAmounts, payer.address);
+          break;
+        case PayerKind.LiquidityPool:
+          throw new Error("The liquidity pool is unable to call the function");
+        default:
+          payer = stranger;
+          // Be sure the function can be called by an alias
+          connect(marketUnderLender, alias).repayLoanForBatch.staticCall(loanIds, repaymentAmounts, payer.address);
+          tx = marketUnderLender.repayLoanForBatch(loanIds, repaymentAmounts, payer.address);
+      }
+
+      const repaidAmountsBefore = expectedLoans.map(loan => loan.state.repaidAmount);
+      const repaymentTimestamp = await getTxTimestamp(tx);
+      const expectedRepaymentAmounts: number[] = [];
+      for (let i = 0; i < expectedLoans.length; ++i) {
+        const expectedLoan = expectedLoans[i];
+        processRepayment(expectedLoan, { repaymentAmount: repaymentAmounts[i], repaymentTimestamp });
+        const expectedRepaymentAmount = expectedLoan.state.repaidAmount - repaidAmountsBefore[i];
+        const actualLoanStateAfterRepayment = await marketUnderLender.getLoanState(expectedLoan.id);
+        checkEquality(actualLoanStateAfterRepayment, expectedLoan.state);
+
+        await expect(tx).to.emit(marketUnderLender, EVENT_NAME_LOAN_REPAYMENT).withArgs(
+          expectedLoan.id,
+          payer.address,
+          borrower.address,
+          expectedRepaymentAmount,
+          expectedLoan.state.trackedBalance // outstanding balance
+        );
+
+        // Check that the appropriate market hook functions are called
+        await expect(tx)
+          .to.emit(liquidityPool, EVENT_NAME_ON_AFTER_LOAN_PAYMENT)
+          .withArgs(expectedLoan.id, expectedRepaymentAmount);
+
+        expectedRepaymentAmounts.push(expectedRepaymentAmount);
+      }
+
+      const totalRepaymentAmount = expectedRepaymentAmounts.length > 0
+        ? expectedRepaymentAmounts.reduce((sum, amount) => sum + amount)
+        : 0;
+      await expect(tx).to.changeTokenBalances(
+        token,
+        [liquidityPool, payer, marketUnderLender],
+        [totalRepaymentAmount, -totalRepaymentAmount, 0]
+      );
+
+      return expectedLoans;
+    }
+
+    describe("Executes as expected if", async () => {
+      it("There are partial repayments from the borrower on the same period the loan is taken", async () => {
+        const fixture = await setUpFixture(deployLendingMarketAndTakeLoans);
+        const currentLoans: Loan[] = [
+          fixture.ordinaryLoan,
+          fixture.installmentLoanParts[fixture.installmentLoanParts.length - 1]
+        ];
+        const repaymentAmounts = [REPAYMENT_AMOUNT, REPAYMENT_AMOUNT / 2];
+        await executeAndCheck(fixture, currentLoans, repaymentAmounts, PayerKind.Borrower);
+      });
+
+      it("There are partial repayments from a stranger before the loan is defaulted", async () => {
+        const fixture = await setUpFixture(deployLendingMarketAndTakeLoans);
+        const currentLoans: Loan[] = [
+          fixture.ordinaryLoan,
+          fixture.installmentLoanParts[fixture.installmentLoanParts.length - 1]
+        ];
+        const repaymentAmounts = [REPAYMENT_AMOUNT, REPAYMENT_AMOUNT / 2];
+        const periodIndex = fixture.ordinaryLoanStartPeriod + fixture.ordinaryLoan.state.durationInPeriods / 2;
+        await increaseBlockTimestampToPeriodIndex(periodIndex);
+        await executeAndCheck(fixture, currentLoans, repaymentAmounts, PayerKind.Stranger);
+      });
+
+      it("There are partial repayment from the borrower at the due date and another one a day after", async () => {
+        const fixture = await setUpFixture(deployLendingMarketAndTakeLoans);
+        const periodIndex = fixture.ordinaryLoanStartPeriod + fixture.ordinaryLoan.state.durationInPeriods;
+        await increaseBlockTimestampToPeriodIndex(periodIndex);
+        let currentLoans: Loan[] = [
+          fixture.ordinaryLoan,
+          fixture.installmentLoanParts[fixture.installmentLoanParts.length - 1]
+        ];
+        const repaymentAmounts = [REPAYMENT_AMOUNT, REPAYMENT_AMOUNT / 2];
+        currentLoans = await executeAndCheck(fixture, currentLoans, repaymentAmounts, PayerKind.Borrower);
+        await increaseBlockTimestampToPeriodIndex(periodIndex + 1);
+        await executeAndCheck(fixture, currentLoans, repaymentAmounts, PayerKind.Borrower);
+      });
+
+      it("There is a full repayment through the amount matches the outstanding balance", async () => {
+        const fixture = await setUpFixture(deployLendingMarketAndTakeLoans);
+        const futureTimestamp = await increaseBlockTimestampToPeriodIndex(fixture.ordinaryLoanStartPeriod + 1);
+        const loanPreview: LoanPreview = determineLoanPreview(fixture.ordinaryLoan, futureTimestamp);
+        const currentLoans: Loan[] = [
+          fixture.ordinaryLoan,
+          fixture.installmentLoanParts[fixture.installmentLoanParts.length - 1]
+        ];
+        const repaymentAmounts = [loanPreview.outstandingBalance, REPAYMENT_AMOUNT];
+        await executeAndCheck(fixture, currentLoans, repaymentAmounts, PayerKind.Borrower);
+      });
+
+      it("There is a full repayment through the amount equals max uint256 value", async () => {
+        const fixture = await setUpFixture(deployLendingMarketAndTakeLoans);
+        const currentLoans: Loan[] = [
+          fixture.ordinaryLoan,
+          fixture.installmentLoanParts[fixture.installmentLoanParts.length - 1]
+        ];
+        const repaymentAmounts = [REPAYMENT_AMOUNT, FULL_REPAYMENT_AMOUNT];
+        await increaseBlockTimestampToPeriodIndex(fixture.installmentLoanStartPeriodIndex + 3);
+        await executeAndCheck(fixture, currentLoans, repaymentAmounts, PayerKind.Borrower);
+      });
+
+      it("There are empty input arrays", async () => {
+        const fixture = await setUpFixture(deployLendingMarketAndTakeLoans);
+        const currentLoans: Loan[] = [];
+        const repaymentAmounts: number[] = [];
+        await increaseBlockTimestampToPeriodIndex(fixture.installmentLoanStartPeriodIndex + 3);
+        await executeAndCheck(fixture, currentLoans, repaymentAmounts, PayerKind.Borrower);
+      });
+    });
+
+    describe("Is reverted if", async () => {
+      it("The contract is paused", async () => {
+        const { market, marketUnderLender } = await setUpFixture(deployLendingMarketAndTakeLoans);
+        await proveTx(market.pause());
+
+        await expect(marketUnderLender.repayLoanForBatch([], [], borrower.address))
+          .to.be.revertedWithCustomError(marketUnderLender, ERROR_NAME_ENFORCED_PAUSED);
+      });
+
+      it("The length of the input arrays does not match", async () => {
+        const { marketUnderLender, installmentLoanParts: loans } = await setUpFixture(deployLendingMarketAndTakeLoans);
+        const loanIds = loans.map(loan => loan.id);
+        const repaymentAmounts: number[] = Array(loans.length).fill(REPAYMENT_AMOUNT);
+
+        await expect(marketUnderLender.repayLoanForBatch(
+          [...loanIds, loanIds[0]],
+          repaymentAmounts,
+          borrower.address
+        )).to.be.revertedWithCustomError(marketUnderLender, ERROR_NAME_ARRAY_LENGTH_MISMATCH);
+
+        await expect(marketUnderLender.repayLoanForBatch(
+          loanIds,
+          [...repaymentAmounts, REPAYMENT_AMOUNT],
+          borrower.address
+        )).to.be.revertedWithCustomError(marketUnderLender, ERROR_NAME_ARRAY_LENGTH_MISMATCH);
+
+        await expect(marketUnderLender.repayLoanForBatch(
+          loanIds,
+          [],
+          borrower.address
+        )).to.be.revertedWithCustomError(marketUnderLender, ERROR_NAME_ARRAY_LENGTH_MISMATCH);
+
+        await expect(marketUnderLender.repayLoanForBatch(
+          [],
+          repaymentAmounts,
+          borrower.address
+        )).to.be.revertedWithCustomError(marketUnderLender, ERROR_NAME_ARRAY_LENGTH_MISMATCH);
+      });
+
+      it("The provided repayer address is zero", async () => {
+        const { marketUnderLender, installmentLoanParts: loans } = await setUpFixture(deployLendingMarketAndTakeLoans);
+        const loanIds = loans.map(loan => loan.id);
+        const repaymentAmounts: number[] = Array(loans.length).fill(REPAYMENT_AMOUNT);
+        const repayerAddress = (ZERO_ADDRESS);
+
+        await expect(
+          marketUnderLender.repayLoanForBatch(loanIds, repaymentAmounts, repayerAddress)
+        ).to.be.revertedWithCustomError(marketUnderLender, ERROR_NAME_ZERO_ADDRESS);
+      });
+
+      it("One of the loans does not exist", async () => {
+        const { marketUnderLender, installmentLoanParts: loans } = await setUpFixture(deployLendingMarketAndTakeLoans);
+        const loanIds = loans.map(loan => loan.id);
+        const repaymentAmounts: number[] = Array(loans.length).fill(REPAYMENT_AMOUNT);
+        loanIds[loanIds.length - 1] += 123;
+
+        await expect(
+          marketUnderLender.repayLoanForBatch(loanIds, repaymentAmounts, borrower.address)
+        ).to.be.revertedWithCustomError(marketUnderLender, ERROR_NAME_LOAN_NOT_EXIST);
+      });
+
+      it("One of the loans is already repaid", async () => {
+        const { marketUnderLender, installmentLoanParts: loans } = await setUpFixture(deployLendingMarketAndTakeLoans);
+        const loanIds = loans.map(loan => loan.id);
+        const repaymentAmounts: number[] = Array(loans.length).fill(REPAYMENT_AMOUNT);
+        await proveTx(marketUnderLender.repayLoanForBatch(
+          [loanIds[loanIds.length - 1]],
+          [FULL_REPAYMENT_AMOUNT],
+          borrower.address
+        ));
+
+        await expect(marketUnderLender.repayLoanForBatch(loanIds, repaymentAmounts, borrower.address))
+          .to.be.revertedWithCustomError(marketUnderLender, ERROR_NAME_LOAN_ALREADY_REPAID);
+      });
+
+      it("The caller is not the lender or an alias", async () => {
+        const { market, installmentLoanParts: loans } = await setUpFixture(deployLendingMarketAndTakeLoans);
+        const loanIds = loans.map(loan => loan.id);
+        const repaymentAmounts: number[] = Array(loans.length).fill(REPAYMENT_AMOUNT);
+
+        await expect(
+          connect(market, owner).repayLoanForBatch(loanIds, repaymentAmounts, borrower.address)
+        ).to.be.revertedWithCustomError(market, ERROR_NAME_UNAUTHORIZED);
+
+        await expect(
+          connect(market, borrower).repayLoanForBatch(loanIds, repaymentAmounts, borrower.address)
+        ).to.be.revertedWithCustomError(market, ERROR_NAME_UNAUTHORIZED);
+
+        await expect(
+          connect(market, stranger).repayLoanForBatch(loanIds, repaymentAmounts, borrower.address)
+        ).to.be.revertedWithCustomError(market, ERROR_NAME_UNAUTHORIZED);
+      });
+
+      it("One of the repayment amounts is zero", async () => {
+        const { marketUnderLender, installmentLoanParts: loans } = await setUpFixture(deployLendingMarketAndTakeLoans);
+        const loanIds = loans.map(loan => loan.id);
+        const repaymentAmounts: number[] = Array(loans.length).fill(REPAYMENT_AMOUNT);
+        repaymentAmounts[loans.length - 1] = 0;
+
+        await expect(marketUnderLender.repayLoanForBatch(loanIds, repaymentAmounts, borrower.address))
+          .to.be.revertedWithCustomError(marketUnderLender, ERROR_NAME_INVALID_AMOUNT);
+      });
+
+      it("One of the repayment amounts is not rounded according to the accuracy factor", async () => {
+        const { marketUnderLender, installmentLoanParts: loans } = await setUpFixture(deployLendingMarketAndTakeLoans);
+        const loanIds = loans.map(loan => loan.id);
+        const repaymentAmounts: number[] = Array(loans.length).fill(REPAYMENT_AMOUNT);
+        repaymentAmounts[loans.length - 1] = REPAYMENT_AMOUNT - 1;
+
+        await expect(marketUnderLender.repayLoanForBatch(loanIds, repaymentAmounts, borrower.address))
+          .to.be.revertedWithCustomError(marketUnderLender, ERROR_NAME_INVALID_AMOUNT);
+      });
+
+      it("One of the repayment amounts is bigger than outstanding balance", async () => {
+        const { marketUnderLender, installmentLoanParts: loans } = await setUpFixture(deployLendingMarketAndTakeLoans);
+        const loanIds = loans.map(loan => loan.id);
+        const repaymentAmounts: number[] = Array(loans.length).fill(REPAYMENT_AMOUNT);
+        const lastLoan = loans[loans.length - 1];
+        repaymentAmounts[loans.length - 1] = Number(roundMath(
+          lastLoan.state.borrowAmount + lastLoan.state.addonAmount,
+          ACCURACY_FACTOR
+        )) + ACCURACY_FACTOR;
+
+        await expect(marketUnderLender.repayLoanForBatch(loanIds, repaymentAmounts, borrower.address))
+          .to.be.revertedWithCustomError(marketUnderLender, ERROR_NAME_INVALID_AMOUNT);
+      });
+    });
+  });
+
   describe("Function 'freeze()'", async () => {
     it("Executes as expected and emits the correct event", async () => {
       const fixture = await setUpFixture(deployLendingMarketAndTakeLoans);

--- a/test/LendingMarket.base.test.ts
+++ b/test/LendingMarket.base.test.ts
@@ -1918,6 +1918,7 @@ describe("Contract 'LendingMarket': base tests", async () => {
 
       // Check that the appropriate market hook functions are called
       await expect(tx).to.emit(liquidityPool, EVENT_NAME_ON_AFTER_LOAN_PAYMENT).withArgs(loan.id, repaymentAmount);
+      await expect(tx).to.emit(creditLine, EVENT_NAME_ON_AFTER_LOAN_PAYMENT).withArgs(loan.id, repaymentAmount);
 
       return expectedLoan;
     }
@@ -2068,6 +2069,9 @@ describe("Contract 'LendingMarket': base tests", async () => {
         // Check that the appropriate market hook functions are called
         await expect(tx)
           .to.emit(liquidityPool, EVENT_NAME_ON_AFTER_LOAN_PAYMENT)
+          .withArgs(expectedLoan.id, expectedRepaymentAmount);
+        await expect(tx)
+          .to.emit(creditLine, EVENT_NAME_ON_AFTER_LOAN_PAYMENT)
           .withArgs(expectedLoan.id, expectedRepaymentAmount);
 
         expectedRepaymentAmounts.push(expectedRepaymentAmount);

--- a/test/credit-lines/CreditLineConfigurable.test.ts
+++ b/test/credit-lines/CreditLineConfigurable.test.ts
@@ -209,7 +209,7 @@ const LATE_FEE_RATE = 987654321n;
 
 const EXPECTED_VERSION: Version = {
   major: 1,
-  minor: 5,
+  minor: 6,
   patch: 0
 };
 

--- a/test/liquidity-pools/LiquidityPoolAccountable.test.ts
+++ b/test/liquidity-pools/LiquidityPoolAccountable.test.ts
@@ -75,7 +75,7 @@ const AUTO_REPAY_LOAN_IDS = [123n, 234n, 345n, 123n];
 const AUTO_REPAY_AMOUNTS = [10_123_456n, 1n, maxUintForBits(256), 0n];
 const EXPECTED_VERSION: Version = {
   major: 1,
-  minor: 5,
+  minor: 6,
   patch: 0
 };
 

--- a/test/mocks/LendingMarketMock.test.ts
+++ b/test/mocks/LendingMarketMock.test.ts
@@ -91,6 +91,13 @@ describe("Contract 'LendingMarketMock'", async () => {
         .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
     });
 
+    it("Function 'repayLoanForBatch()'", async () => {
+      const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
+
+      await expect(lendingMarket.repayLoanForBatch([], [], MOCK_ADDRESS))
+        .to.be.revertedWithCustomError(lendingMarket, ERROR_NAME_NOT_IMPLEMENTED);
+    });
+
     it("Function 'freeze()'", async () => {
       const { lendingMarket } = await setUpFixture(deployLendingMarketMock);
 


### PR DESCRIPTION
## Main changes
1. The new `repayLoanForBatch()` function has been introduced to execute multiple repayments.
2. The new function can be called only by service accounts that are configured as aliases of the lender account.
3. The new function allows to provide any address as the token source (`repayer`).
4. No new event has been introduced. The new function emits the existing `LoanRepayment` event for each repayment. The event already has a `repayer` field to notify the source address of the tokens for repayments.
5. The new function definition:
```solidity
    /// @dev Repays a batch of loans.
    ///
    /// Can be called only by an account with a special role.
    ///
    /// @param loanIds The unique identifiers of the loans to repay.
    /// @param repaymentAmounts The amounts to repay for each loan.
    /// @param repayer The address of the token source for the repayments (borrower or third-party).
    function repayLoanForBatch(
        uint256[] calldata loanIds,
        uint256[] calldata repaymentAmounts,
        address repayer
    ) external;
```

## Versioning

The new version of the smart-contracts is `1.6.0`.

## Test Coverage

The new function is fully covered by tests.

<details>

<summary>Test coverage details</summary>

| File                                    |  % Stmts | % Branch |  % Funcs |  % Lines |
|-----------------------------------------|---------:|---------:|---------:|---------:|
| contracts/                              |   100.00 |    99.07 |   100.00 |   100.00 |
| ├─ LendingMarket.sol                    |   100.00 |    99.06 |   100.00 |   100.00 |
| ├─ LendingMarketStorage.sol             |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketUUPS.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/                       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeable.sol      |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/interfaces/            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICreditLineConfigurable.sol          |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILiquidityPoolAccountable.sol        |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/interfaces/core/       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICreditLine.sol                      |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILendingMarket.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILiquidityPool.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/common/libraries/             |   100.00 |    70.00 |   100.00 |    100.00 |
| ├─ ABDKMath64x64.sol                    |   100.00 |    65.91 |   100.00 |    100.00 |
| ├─ Constants.sol                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Error.sol                            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ InterestMath.sol                     |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Loan.sol                             |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Round.sol                            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ SafeCast.sol                         |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/credit-lines/                 |   100.00 |    97.37 |   100.00 |   100.00 |
| ├─ CreditLineConfigurable.sol           |   100.00 |    97.32 |   100.00 |   100.00 |
| ├─ CreditLineConfigurableUUPS.sol       |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/liquidity-pools/              |   100.00 |    97.22 |   100.00 |   100.00 |
| ├─ LiquidityPoolAccountable.sol         |   100.00 |    97.14 |   100.00 |   100.00 |
| ├─ LiquidityPoolAccountableUUPS.sol     |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/mocks/                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeableMock.sol  |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineMock.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ERC20Mock.sol                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketMock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPoolMock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/testables/                    |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineConfigurableTestable.sol   |   100.00 |   100.00 |   100.00 |   100.00 |
|-----------------------------------------|----------|----------|----------|----------|
| All files                               |   100.00 |    95.28 |   100.00 |    100.00 |
|-----------------------------------------|----------|----------|----------|----------|
</details>