### PR TITLE
feat: new token flow on loan taking and revocation

### DIFF
--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -1183,15 +1183,18 @@ contract LendingMarket is
         address liquidityPool = _programLiquidityPools[loan.programId];
         address token = loan.token;
         address addonTreasury = ILiquidityPool(liquidityPool).addonTreasury();
+        address borrower = loan.borrower;
 
-        if (repaidAmount < borrowAmount) {
-            IERC20(loan.token).safeTransferFrom(loan.borrower, liquidityPool, borrowAmount - repaidAmount);
-        } else if (repaidAmount != borrowAmount) {
-            IERC20(loan.token).safeTransferFrom(liquidityPool, loan.borrower, repaidAmount - borrowAmount);
-        }
         if (addonTreasury != address(0)) {
-            IERC20(token).safeTransferFrom(addonTreasury, liquidityPool, addonAmount);
+            IERC20(token).safeTransferFrom(addonTreasury, borrower, addonAmount);
+            borrowAmount += addonAmount; // Reuse the 'borrowAmount' as the principal amount
         }
+        if (repaidAmount < borrowAmount) {
+            IERC20(loan.token).safeTransferFrom(borrower, liquidityPool, borrowAmount - repaidAmount);
+        } else if (repaidAmount != borrowAmount) {
+            IERC20(loan.token).safeTransferFrom(liquidityPool, borrower, repaidAmount - borrowAmount);
+        }
+
     }
 
     /// @inheritdoc ILendingMarket

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -1160,9 +1160,12 @@ contract LendingMarket is
         address liquidityPool = _programLiquidityPools[loan.programId];
         address token = loan.token;
         address addonTreasury = ILiquidityPool(liquidityPool).addonTreasury();
-        IERC20(token).safeTransferFrom(liquidityPool, loan.borrower, borrowAmount);
+        address borrower = loan.borrower;
+        IERC20(token).safeTransferFrom(liquidityPool, borrower, borrowAmount + addonAmount);
         if (addonTreasury != address(0)) {
-            IERC20(token).safeTransferFrom(liquidityPool, addonTreasury, addonAmount);
+            IERC20(token).safeTransferFrom(borrower, addonTreasury, addonAmount);
+        } else {
+            IERC20(token).safeTransferFrom(borrower, liquidityPool, addonAmount);
         }
     }
 

--- a/test/LendingMarket.base.test.ts
+++ b/test/LendingMarket.base.test.ts
@@ -1125,6 +1125,11 @@ describe("Contract 'LendingMarket': base tests", async () => {
         );
       }
 
+      // Check that there is a transfer of principal form the liquidity pool to the borrower
+      await expect(tx)
+        .to.emit(token, EVENT_NAME_TRANSFER)
+        .withArgs(liquidityPoolAddress, borrower.address, principalAmount);
+
       await expect(tx)
         .to.emit(market, EVENT_NAME_LOAN_TAKEN)
         .withArgs(expectedLoanId, borrower.address, principalAmount, DURATION_IN_PERIODS);
@@ -1272,6 +1277,11 @@ describe("Contract 'LendingMarket': base tests", async () => {
           [-BORROW_AMOUNT, +BORROW_AMOUNT, 0, 0]
         );
       }
+
+      // Check that there is a transfer of principal form the liquidity pool to the borrower
+      await expect(tx)
+        .to.emit(token, EVENT_NAME_TRANSFER)
+        .withArgs(liquidityPoolAddress, borrower.address, principalAmount);
 
       await expect(tx)
         .to.emit(market, EVENT_NAME_LOAN_TAKEN)
@@ -1587,15 +1597,19 @@ describe("Contract 'LendingMarket': base tests", async () => {
           [liquidityPool, borrower, addonTreasury, market],
           [-totalPrincipal, +totalBorrowAmount, +totalAddonAmount, 0]
         );
-        expect(await getNumberOfEvents(tx, token, EVENT_NAME_TRANSFER)).to.eq(2);
       } else {
         await expect(tx).to.changeTokenBalances(
           token,
           [liquidityPool, borrower, addonTreasury, market],
           [-totalBorrowAmount, +totalBorrowAmount, 0, 0]
         );
-        expect(await getNumberOfEvents(tx, token, EVENT_NAME_TRANSFER)).to.eq(1);
       }
+      expect(await getNumberOfEvents(tx, token, EVENT_NAME_TRANSFER)).to.eq(2);
+
+      // Check that there is a transfer of principal form the liquidity pool to the borrower
+      await expect(tx)
+        .to.emit(token, EVENT_NAME_TRANSFER)
+        .withArgs(liquidityPoolAddress, borrower.address, totalPrincipal);
 
       // Check the returned value of the function for the second loan
       const nextActualLoanId: bigint = await connect(market, lender).takeLoanFor.staticCall(


### PR DESCRIPTION
## Main changes

#### 1. The token flow on loan taking was changed:
- Current flow: 
  - `borrow amount: liquidity pool -> user's wallet`
  - `IOF amount: liquidity pool -> IOF wallet`
- New flow:
  - `borrow amount + IOF amount: liquidity pool -> user's wallet`
  - `IOF amount: user's wallet -> IOF wallet`

#### 2.1 The token flow on loan revocation was changed (repaid amount < borrow amount):
- Current flow: 
  - `borrow amount - repaid amount: user's wallet -> liquidity pool`
  - `IOF amount: IOF wallet -> liquidity pool`
- New flow:
  - `IOF amount: IOF wallet -> user's wallet`
  - `borrow amount + IOF amount - repaid amount: user's wallet -> liquidity pool`

#### 2.2 The token flow on loan revocation was changed (repaid amount != borrow amount):
- Current flow: 
  - `repaid amount - borrow amount: liquidity pool -> user's wallet`
  - `IOF amount: IOF wallet -> liquidity pool`
- New flow:
  - `IOF amount: IOF wallet -> user's wallet`
  - `repaid amount - (borrow amount + IOF amount): liquidity pool -> user's wallet`

## Test Coverage
The new function is fully covered by tests.
  