### PR TITLE
feat: add the ability to transfer tokens during undoing repayments

### DIFF
--- a/contracts/LiquidityPool.sol
+++ b/contracts/LiquidityPool.sol
@@ -231,6 +231,12 @@ contract LiquidityPool is
     }
 
     /// @inheritdoc ILiquidityPoolHooks
+    function onAfterLoanRepaymentUndoing(uint256 loanId, uint256 amount) external whenNotPaused onlyMarket {
+        loanId; // To prevent compiler warning about unused variable
+        _borrowableBalance -= amount.toUint64();
+    }
+
+    /// @inheritdoc ILiquidityPoolHooks
     function onAfterLoanRevocation(uint256 loanId) external whenNotPaused onlyMarket {
         Loan.State memory loan = ILendingMarket(_market).getLoanState(loanId);
         if (loan.borrowedAmount > loan.repaidAmount) {

--- a/contracts/base/Versionable.sol
+++ b/contracts/base/Versionable.sol
@@ -10,6 +10,6 @@ import "../interfaces/IVersionable.sol";
 abstract contract Versionable is IVersionable {
     /// @inheritdoc IVersionable
     function $__VERSION() external pure returns (Version memory) {
-        return Version(1, 11, 0);
+        return Version(1, 11, 1);
     }
 }

--- a/contracts/interfaces/ILendingMarket.sol
+++ b/contracts/interfaces/ILendingMarket.sol
@@ -97,6 +97,8 @@ interface ILendingMarketPrimary {
 
     /// @dev Emitted when a repayment is undone.
     /// @param loanId The unique identifier of the loan.
+    /// @param receiver The address of the receiver of the tokens due to the repayment undoing.
+    /// @param borrower The address of the borrower of the loan.
     /// @param repaymentTimestamp The timestamp of the repayment in the lending market time zone.
     /// @param newRepaidAmount The new repaid amount of the loan.
     /// @param oldRepaidAmount The old repaid amount of the loan.
@@ -106,6 +108,8 @@ interface ILendingMarketPrimary {
     /// @param oldLateFeeAmount The old late fee amount of the loan.
     event RepaymentUndone(
         uint256 indexed loanId,
+        address indexed receiver,
+        address indexed borrower,
         uint256 repaymentTimestamp,
         uint256 newRepaidAmount,
         uint256 oldRepaidAmount,
@@ -271,10 +275,12 @@ interface ILendingMarketPrimary {
     /// @param loanId The unique identifier of the loan.
     /// @param repaymentAmount The amount of the repayment to undo.
     /// @param repaymentTimestamp The timestamp of the repayment in the lending market time zone.
+    /// @param receiver The address of the receiver of the tokens due to the repayment undoing.
     function undoRepaymentFor(
         uint256 loanId, // Tools: this comment prevents Prettier from formatting into a single line.
         uint256 repaymentAmount,
-        uint256 repaymentTimestamp
+        uint256 repaymentTimestamp,
+        address receiver
     ) external;
 
     /// @dev Freezes an ordinary loan or a sub-loan.

--- a/contracts/interfaces/ILiquidityPool.sol
+++ b/contracts/interfaces/ILiquidityPool.sol
@@ -114,6 +114,11 @@ interface ILiquidityPoolHooks {
     /// @param repaymentAmount The amount of tokens that was repaid.
     function onAfterLoanPayment(uint256 loanId, uint256 repaymentAmount) external;
 
+    /// @dev A hook that is triggered by the associated market after the loan repayment undoing.
+    /// @param loanId The unique identifier of the loan to undo the repayment for.
+    /// @param repaymentAmount The amount of tokens that was undone.
+    function onAfterLoanRepaymentUndoing(uint256 loanId, uint256 repaymentAmount) external;
+
     /// @dev A hook that is triggered by the associated market after the loan revocation.
     /// @param loanId The unique identifier of the loan being revoked.
     function onAfterLoanRevocation(uint256 loanId) external;

--- a/contracts/mocks/LendingMarketMock.sol
+++ b/contracts/mocks/LendingMarketMock.sol
@@ -37,6 +37,13 @@ contract LendingMarketMock {
         ILiquidityPool(liquidityPool).onAfterLoanPayment(loanId, amount);
     }
 
+    function callOnAfterLoanRepaymentUndoingLiquidityPool(
+        address liquidityPool,
+        uint256 loanId, uint256 amount
+    ) external {
+        ILiquidityPool(liquidityPool).onAfterLoanRepaymentUndoing(loanId, amount);
+    }
+
     function callOnAfterLoanPaymentCreditLine(address creditLine, uint256 loanId, uint256 repaymentAmount) external {
         ICreditLine(creditLine).onAfterLoanPayment(loanId, repaymentAmount);
     }

--- a/contracts/mocks/LiquidityPoolMock.sol
+++ b/contracts/mocks/LiquidityPoolMock.sol
@@ -23,6 +23,7 @@ contract LiquidityPoolMock {
 
     event OnBeforeLoanTakenCalled(uint256 indexed loanId);
     event OnAfterLoanPaymentCalled(uint256 indexed loanId, uint256 indexed repaymentAmount);
+    event OnAfterLoanRepaymentUndoingCalled(uint256 indexed loanId, uint256 indexed repaymentAmount);
     event OnAfterLoanRevocationCalled(uint256 indexed loanId);
 
     // -------------------------------------------- //
@@ -35,6 +36,10 @@ contract LiquidityPoolMock {
 
     function onAfterLoanPayment(uint256 loanId, uint256 repaymentAmount) external {
         emit OnAfterLoanPaymentCalled(loanId, repaymentAmount);
+    }
+
+    function onAfterLoanRepaymentUndoing(uint256 loanId, uint256 repaymentAmount) external {
+        emit OnAfterLoanRepaymentUndoingCalled(loanId, repaymentAmount);
     }
 
     function onAfterLoanRevocation(uint256 loanId) external {

--- a/test/CreditLine.test.ts
+++ b/test/CreditLine.test.ts
@@ -260,7 +260,7 @@ const FUNC_DETERMINE_LATE_FEE_AMOUNT_LEGACY =
 const EXPECTED_VERSION: Version = {
   major: 1,
   minor: 11,
-  patch: 0
+  patch: 1
 };
 
 function processLoanClosing(borrowerState: BorrowerState, borrowedAmount: bigint) {

--- a/test/LendingMarket.base.test.ts
+++ b/test/LendingMarket.base.test.ts
@@ -221,7 +221,7 @@ const DURATIONS_IN_PERIODS: number[] = [0, DURATION_IN_PERIODS / 2, DURATION_IN_
 const EXPECTED_VERSION: Version = {
   major: 1,
   minor: 11,
-  patch: 0
+  patch: 1
 };
 
 const defaultLoanState: LoanState = {

--- a/test/LiquidityPool.test.ts
+++ b/test/LiquidityPool.test.ts
@@ -70,7 +70,7 @@ const LOAN_ID = 123n;
 const EXPECTED_VERSION: Version = {
   major: 1,
   minor: 11,
-  patch: 0
+  patch: 1
 };
 
 const defaultLoanState: LoanState = {


### PR DESCRIPTION
## Main changes
1. The ability to transfer tokens within the `undoRepaymentFor()` function has been added.

2. Tokens will be transferred to the `receiver` account that has been added as the last parameter of the function. The new function definition:

    <details>
    
    <summary>The new function definition </summary>
    
    ```solidity
    /// @dev Undoes a repayment for a loan.
    /// @param loanId The unique identifier of the loan.
    /// @param repaymentAmount The amount of the repayment to undo.
    /// @param repaymentTimestamp The timestamp of the repayment in the lending market time zone.
    /// @param receiver The address of the receiver of the tokens due to the repayment undoing.
    function undoRepaymentFor(
        uint256 loanId, // Tools: this comment prevents Prettier from formatting into a single line.
        uint256 repaymentAmount,
        uint256 repaymentTimestamp,
        address receiver
    ) external whenNotPaused onlyOngoingLoan(loanId) onlyRole(ADMIN_ROLE) {....};
    ```
    
    </details>

3. If the provide `receiver` address is zero the tokens transfer will be bypassed.

4. The new `receiver` and `borrower` fields has been added to the `RepaymentUndone` event:

    <details>
    
    <summary>The new event definition </summary>
    
    ```solidity
    /// @dev Emitted when a repayment is undone.
    /// @param loanId The unique identifier of the loan.
    /// @param receiver The address of the receiver of the tokens due to the repayment undoing.
    /// @param borrower The address of the borrower of the loan.
    /// @param repaymentTimestamp The timestamp of the repayment in the lending market time zone.
    /// @param newRepaidAmount The new repaid amount of the loan.
    /// @param oldRepaidAmount The old repaid amount of the loan.
    /// @param newTrackedBalance The new tracked balance of the loan.
    /// @param oldTrackedBalance The old tracked balance of the loan.
    /// @param newLateFeeAmount The new late fee amount of the loan.
    /// @param oldLateFeeAmount The old late fee amount of the loan.
    event RepaymentUndone(
        uint256 indexed loanId,
        address indexed receiver,
        address indexed borrower,
        uint256 repaymentTimestamp,
        uint256 newRepaidAmount,
        uint256 oldRepaidAmount,
        uint256 newTrackedBalance,
        uint256 oldTrackedBalance,
        uint256 newLateFeeAmount,
        uint256 oldLateFeeAmount
    );
    ```
    
    </details>

5. The new `onAfterLoanRepaymentUndoing()` hook function has been added to the liquidity pool smart contract. It is called when a repayment is being undone to decrease the borrowable balance of the pool.

## Versioning

The smart contracts version has been updated to `v1.11.1`.

## Test Coverage

The new changes have been fully covered by tests. 

<details>

<summary>Test coverage details</summary>

| File                                    |  % Stmts | % Branch |  % Funcs |  % Lines |
|-----------------------------------------|---------:|---------:|---------:|---------:|
| contracts/                              |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLine.sol                       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineStorage.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarket.sol                    |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketStorage.sol             |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPool.sol                    |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPoolStorage.sol             |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/base/                         |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeable.sol      |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ PausableExtUpgradeable.sol           |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ UUPSExtUpgradeable.sol               |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Versionable.sol                      |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/interfaces/                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICreditLine.sol                      |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICreditLineTypes.sol                 |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILendingMarket.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILiquidityPool.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ IVersionable.sol                     |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/libraries/                    |   100.00 |    98.00 |   100.00 |   100.00 |
| ├─ ABDKMath64x64.sol                    |   100.00 |    97.73 |   100.00 |   100.00 |
| ├─ Constants.sol                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Error.sol                            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ InterestMath.sol                     |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Loan.sol                             |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Rounding.sol                         |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ SafeCast.sol                         |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/mocks/                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ABDKMath64x64Mock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeableMock.sol  |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineMock.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ERC20Mock.sol                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketMock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPoolMock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ PausableExtUpgradeableMock.sol       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ RoundingMock.sol                     |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ UUPSExtUpgradableMock.sol            |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/testables/                    |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineTestable.sol               |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketTestable.sol            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPoolTestable.sol            |   100.00 |   100.00 |   100.00 |   100.00 |
|-----------------------------------------|----------|----------|----------|----------|
| All files                               |   100.00 |    99.79 |   100.00 |   100.00 |
|-----------------------------------------|----------|----------|----------|----------|

</details>
