### PR TITLE
feat: allow to undo repayments for fully repaid loans

### DIFF
--- a/contracts/CreditLine.sol
+++ b/contracts/CreditLine.sol
@@ -243,6 +243,12 @@ contract CreditLine is
     }
 
     /// @inheritdoc ICreditLineHooks
+    function onBeforeLoanReopened(uint256 loanId) external whenNotPaused onlyMarket {
+        Loan.State memory loan = ILendingMarket(_market).getLoanState(loanId);
+        _openLoan(loan);
+    }
+
+    /// @inheritdoc ICreditLineHooks
     function onAfterLoanPayment(uint256 loanId, uint256 repaymentAmount) external whenNotPaused onlyMarket {
         repaymentAmount; // To prevent compiler warning about unused variable
 

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -366,13 +366,14 @@ contract LendingMarket is
             newLateFeeAmount,
             oldLateFeeAmount
         );
+        loan.repaidAmount = newRepaidAmount.toUint64();
+        loan.trackedBalance = newTrackedBalance.toUint64();
+        loan.lateFeeAmount = newLateFeeAmount.toUint64();
+
         if (oldTrackedBalance == 0) {
             address creditLine = _programCreditLines[loan.programId];
             ICreditLine(creditLine).onBeforeLoanReopened(loanId);
         }
-        loan.repaidAmount = newRepaidAmount.toUint64();
-        loan.trackedBalance = newTrackedBalance.toUint64();
-        loan.lateFeeAmount = newLateFeeAmount.toUint64();
 
         if (receiver != address(0)) {
             address liquidityPool = _programLiquidityPools[loan.programId];

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -337,7 +337,7 @@ contract LendingMarket is
         {
             uint256 dueTimestamp = _getDueTimestamp(loan);
             if (repaymentTimestamp <= dueTimestamp && oldLateFeeAmount != 0) {
-                (uint256 additionalLateFeeAmount,) = _calculateCustomTrackedBalance(
+                (uint256 additionalLateFeeAmount, ) = _calculateCustomTrackedBalance(
                     loan,
                     repaymentAmount,
                     repaymentTimestamp,

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -884,12 +884,6 @@ contract LendingMarket is
         if (repaymentTimestamp < loan.startTimestamp) {
             revert RepaymentTimestampInvalid();
         }
-        if (loan.trackedTimestamp == repaymentTimestamp && loan.trackedBalance == 0) {
-            return; // Skip further checks for the last repayment of a closed loan
-        }
-        if (roundedRepaymentAmount != repaymentAmount) {
-            revert UndoingRepaymentAmountUnrounded();
-        }
     }
 
     /// @dev Calculates the tracked balance of a loan.

--- a/contracts/base/Versionable.sol
+++ b/contracts/base/Versionable.sol
@@ -10,6 +10,6 @@ import "../interfaces/IVersionable.sol";
 abstract contract Versionable is IVersionable {
     /// @inheritdoc IVersionable
     function $__VERSION() external pure returns (Version memory) {
-        return Version(1, 11, 1);
+        return Version(1, 12, 0);
     }
 }

--- a/contracts/interfaces/ICreditLine.sol
+++ b/contracts/interfaces/ICreditLine.sol
@@ -125,6 +125,10 @@ interface ICreditLineHooks {
     /// @param loanId The unique identifier of the loan being taken.
     function onBeforeLoanTaken(uint256 loanId) external;
 
+    /// @dev A hook that is triggered by the associated market before a loan is reopened.
+    /// @param loanId The unique identifier of the loan being opened.
+    function onBeforeLoanReopened(uint256 loanId) external;
+
     /// @dev A hook that is triggered by the associated market after the loan payment.
     /// @param loanId The unique identifier of the loan being paid.
     /// @param repaymentAmount The amount of tokens that was repaid.

--- a/contracts/interfaces/ILendingMarket.sol
+++ b/contracts/interfaces/ILendingMarket.sol
@@ -515,9 +515,6 @@ interface ILendingMarketErrors {
 
     /// @dev Thrown when the provided repayment timestamp is invalid.
     error RepaymentTimestampInvalid();
-
-    /// @dev Thrown when undoing repayment amount is not rounded as required for non-final repayments.
-    error UndoingRepaymentAmountUnrounded();
 }
 
 /// @title ILendingMarket interface

--- a/contracts/interfaces/ILendingMarket.sol
+++ b/contracts/interfaces/ILendingMarket.sol
@@ -515,6 +515,9 @@ interface ILendingMarketErrors {
 
     /// @dev Thrown when the provided repayment timestamp is invalid.
     error RepaymentTimestampInvalid();
+
+    /// @dev Thrown when undoing repayment amount is not rounded as required for non-final repayments.
+    error UndoingRepaymentAmountUnrounded();
 }
 
 /// @title ILendingMarket interface

--- a/contracts/interfaces/ILendingMarket.sol
+++ b/contracts/interfaces/ILendingMarket.sol
@@ -271,6 +271,21 @@ interface ILendingMarketPrimary {
     /// 4. The formulas can be used for a loan that was only frozen, in that case the tt is the freezing timestamp.
     /// 5. After undoing a repayment, the values of the tracked balance and late fee amount fields of a loan
     ///    may differ from the expected values by plus or minus one least significant bit due to rounding.
+    /// 6. There are final and ordinary repayments to undo. The final repayment is one that caused closing of a loan.
+    /// 7. To properly undo a final repayment the caller must provide the tracked balance of the loan before
+    ///    the repayment instead of the final repayment amount.
+    ///    To get the right tracked balance the following steps should be used:
+    ///        * a. Determine the block of the final repayment: `B`.
+    ///        * b. Determine the timestamp of the `B` block: `BT`.
+    ///        * c. Determine the timestamp in the timezone of the lending contract: `BTZ`.
+    ///             E.g. for `America/Sao_Paulo` timezone: `BTZ = BT - 3 * 60 * 60`.
+    ///        * d. Call the `getLoanPreview()` function at the `B-1` block with the `BTZ` timestamp.
+    ///        * e. Use the trackedBalance field of the returned structure as the `repaymentAmount` parameter
+    ///             to undo the final repayment.
+    /// 8. The recommended algorithm for selecting the value of parameter `repaymentAmount`:
+    ///        * a. If the being undone repayment is NOT a final one use its repayment amount as the value.
+    ///        * b. Otherwise the repayment is a final one and so use the tracked balance of the loan before
+    ///             the repayment as the value. See the previous note for details.
     ///
     /// @param loanId The unique identifier of the loan.
     /// @param repaymentAmount The amount of the repayment to undo.

--- a/contracts/mocks/CreditLineMock.sol
+++ b/contracts/mocks/CreditLineMock.sol
@@ -23,6 +23,7 @@ contract CreditLineMock {
     // -------------------------------------------- //
 
     event OnBeforeLoanTakenCalled(uint256 indexed loanId);
+    event OnBeforeLoanReopenedCalled(uint256 indexed loanId);
     event OnAfterLoanPaymentCalled(uint256 indexed loanId, uint256 indexed repaymentAmount);
     event OnAfterLoanRevocationCalled(uint256 indexed loanId);
 
@@ -32,6 +33,10 @@ contract CreditLineMock {
 
     function onBeforeLoanTaken(uint256 loanId) external {
         emit OnBeforeLoanTakenCalled(loanId);
+    }
+
+    function onBeforeLoanReopened(uint256 loanId) external {
+        emit OnBeforeLoanReopenedCalled(loanId);
     }
 
     function onAfterLoanPayment(uint256 loanId, uint256 repaymentAmount) external {

--- a/contracts/mocks/LendingMarketMock.sol
+++ b/contracts/mocks/LendingMarketMock.sol
@@ -33,13 +33,18 @@ contract LendingMarketMock {
         ICreditLine(creditLine).onBeforeLoanTaken(loanId);
     }
 
+    function callOnBeforeLoanReopenedCreditLine(address creditLine, uint256 loanId) external {
+        ICreditLine(creditLine).onBeforeLoanReopened(loanId);
+    }
+
     function callOnAfterLoanPaymentLiquidityPool(address liquidityPool, uint256 loanId, uint256 amount) external {
         ILiquidityPool(liquidityPool).onAfterLoanPayment(loanId, amount);
     }
 
     function callOnAfterLoanRepaymentUndoingLiquidityPool(
         address liquidityPool,
-        uint256 loanId, uint256 amount
+        uint256 loanId,
+        uint256 amount
     ) external {
         ILiquidityPool(liquidityPool).onAfterLoanRepaymentUndoing(loanId, amount);
     }

--- a/contracts/testables/LendingMarketTestable.sol
+++ b/contracts/testables/LendingMarketTestable.sol
@@ -15,8 +15,8 @@ contract LendingMarketTestable is LendingMarket {
     /// @dev The maximum number of installments. Non-zero value overrides the constant in Constants.sol.
     uint256 public installmentCountMax;
 
-    /// @dev Flag to allow zero amounts for loans in test purposes.
-    bool public areZeroAmountsAllowed;
+    /// @dev Flag to allow any amount for loans in test purposes.
+    bool public areAnyAmountsAllowed;
 
     // -------------------------------------------- //
     //  Transactional functions                     //
@@ -77,9 +77,9 @@ contract LendingMarketTestable is LendingMarket {
         }
     }
 
-    /// @dev Allow zero amounts for a batch of loans.
-    function allowZeroAmounts() external {
-        areZeroAmountsAllowed = true;
+    /// @dev Allow any amounts for a batch of loans.
+    function allowAnyAmounts() external {
+        areAnyAmountsAllowed = true;
     }
 
     /// @dev Freeze a batch of loans.
@@ -109,10 +109,10 @@ contract LendingMarketTestable is LendingMarket {
     /// @dev Overrides the same name function in the lending market contract to allow zero amounts if the flag is set.
     /// @param changeAmount The amount of change in the tracked balance.
     function _checkTrackedBalanceChange(uint256 changeAmount) internal view override {
-        if (!areZeroAmountsAllowed) {
+        if (!areAnyAmountsAllowed) {
             super._checkTrackedBalanceChange(changeAmount);
         } else {
-            // just do nothing and allow zero amounts
+            // just do nothing and allow any amounts
         }
     }
 }

--- a/test/CreditLine.test.ts
+++ b/test/CreditLine.test.ts
@@ -1279,6 +1279,105 @@ describe("Contract 'CreditLine'", async () => {
     });
   });
 
+  describe("Function 'onBeforeLoanReopened()'", async () => {
+    it("Executes as expected if the borrowing policy is 'SingleActiveLoan'", async () => {
+      await executeAndCheckLoanOpeningHook(
+        "callOnBeforeLoanReopenedCreditLine(address,uint256)",
+        BorrowingPolicy.SingleActiveLoan
+      );
+    });
+
+    it("Executes as expected if the borrowing policy is 'MultipleActiveLoan'", async () => {
+      await executeAndCheckLoanOpeningHook(
+        "callOnBeforeLoanReopenedCreditLine(address,uint256)",
+        BorrowingPolicy.MultipleActiveLoans
+      );
+    });
+
+    it("Executes as expected if the borrowing policy is 'TotalActiveAmountLimit'", async () => {
+      await executeAndCheckLoanOpeningHook(
+        "callOnBeforeLoanReopenedCreditLine(address,uint256)",
+        BorrowingPolicy.TotalActiveAmountLimit
+      );
+    });
+
+    it("Is reverted if the caller is not the configured market", async () => {
+      const { creditLine } = await setUpFixture(deployAndConfigureContractsWithBorrower);
+
+      await expect(creditLine.onBeforeLoanReopened(LOAN_ID))
+        .to.be.revertedWithCustomError(creditLine, ERROR_NAME_UNAUTHORIZED);
+    });
+
+    it("Is reverted if the contract is paused", async () => {
+      const { creditLine } = await setUpFixture(deployAndConfigureContractsWithBorrower);
+      await proveTx(creditLine.pause());
+
+      await expect(market.callOnBeforeLoanReopenedCreditLine(getAddress(creditLine), LOAN_ID))
+        .to.be.revertedWithCustomError(creditLine, ERROR_NAME_ENFORCED_PAUSED);
+    });
+
+    it("Is reverted if the borrowing policy is 'SingleActiveLoan' but there is another active loan", async () => {
+      const fixture = await setUpFixture(deployAndConfigureContractsWithBorrower);
+      const { creditLine, creditLineUnderAdmin, borrowerConfig } = fixture;
+      await prepareLoan(market);
+      const borrowerConfigNew = { ...borrowerConfig, borrowingPolicy: BorrowingPolicy.SingleActiveLoan };
+      const borrowerState: BorrowerState = {
+        ...defaultBorrowerState,
+        activeLoanCount: 1n
+      };
+      await proveTx(creditLineUnderAdmin[FUNC_CONFIGURE_BORROWER_NEW](borrower.address, borrowerConfigNew));
+      await proveTx(creditLineUnderAdmin.setBorrowerState(borrower.address, borrowerState));
+
+      await expect(market.callOnBeforeLoanReopenedCreditLine(getAddress(creditLine), LOAN_ID))
+        .to.revertedWithCustomError(creditLine, ERROR_NAME_LIMIT_VIOLATION_ON_SINGLE_ACTIVE_LOAN);
+    });
+
+    it("Is reverted if the borrowing policy is 'TotalActiveAmountLimit' but total amount excess happens", async () => {
+      const fixture = await setUpFixture(deployAndConfigureContractsWithBorrower);
+      const { creditLine, creditLineUnderAdmin, borrowerConfig } = fixture;
+      const loanState: LoanState = await prepareLoan(market);
+      const borrowerConfigNew = { ...borrowerConfig, borrowingPolicy: BorrowingPolicy.TotalActiveAmountLimit };
+      const borrowerState: BorrowerState = {
+        ...defaultBorrowerState,
+        totalActiveLoanAmount: borrowerConfig.maxBorrowedAmount - loanState.borrowedAmount + 1n
+      };
+      await proveTx(creditLineUnderAdmin[FUNC_CONFIGURE_BORROWER_NEW](borrower.address, borrowerConfigNew));
+      await proveTx(creditLineUnderAdmin.setBorrowerState(borrower.address, borrowerState));
+
+      await expect(market.callOnBeforeLoanReopenedCreditLine(getAddress(creditLine), LOAN_ID))
+        .to.revertedWithCustomError(creditLine, ERROR_NAME_LIMIT_VIOLATION_ON_TOTAL_ACTIVE_LOAN_AMOUNT)
+        .withArgs(borrowerState.totalActiveLoanAmount + BigInt(BORROWED_AMOUNT));
+    });
+
+    it("Is reverted if the result total number of loans is greater than 16-bit unsigned integer", async () => {
+      const { creditLine, creditLineUnderAdmin } = await setUpFixture(deployAndConfigureContractsWithBorrower);
+      const borrowerState: BorrowerState = {
+        ...defaultBorrowerState,
+        activeLoanCount: 0n,
+        closedLoanCount: maxUintForBits(16)
+      };
+      await proveTx(creditLineUnderAdmin.setBorrowerState(borrower.address, borrowerState));
+      await prepareLoan(market);
+
+      await expect(market.callOnBeforeLoanReopenedCreditLine(getAddress(creditLine), LOAN_ID))
+        .to.revertedWithCustomError(creditLine, ERROR_NAME_BORROWER_STATE_OVERFLOW);
+    });
+
+    it("Is reverted if the result total amount of loans is greater than 64-bit unsigned integer", async () => {
+      const { creditLine, creditLineUnderAdmin } = await setUpFixture(deployAndConfigureContractsWithBorrower);
+      const borrowerState: BorrowerState = {
+        ...defaultBorrowerState,
+        totalActiveLoanAmount: 0n,
+        totalClosedLoanAmount: maxUintForBits(64) - BORROWED_AMOUNT + 1n
+      };
+      await proveTx(creditLineUnderAdmin.setBorrowerState(borrower.address, borrowerState));
+      await prepareLoan(market);
+
+      await expect(market.callOnBeforeLoanReopenedCreditLine(getAddress(creditLine), LOAN_ID))
+        .to.revertedWithCustomError(creditLine, ERROR_NAME_BORROWER_STATE_OVERFLOW);
+    });
+  });
+
   describe("Function onAfterLoanPayment()", async () => {
     it("Executes as expected if the loan tracked balance is not zero", async () => {
       const { creditLine } = await setUpFixture(deployAndConfigureContractsWithBorrower);

--- a/test/CreditLine.test.ts
+++ b/test/CreditLine.test.ts
@@ -259,8 +259,8 @@ const FUNC_DETERMINE_LATE_FEE_AMOUNT_LEGACY =
 
 const EXPECTED_VERSION: Version = {
   major: 1,
-  minor: 11,
-  patch: 1
+  minor: 12,
+  patch: 0
 };
 
 function processLoanClosing(borrowerState: BorrowerState, borrowedAmount: bigint) {

--- a/test/CreditLine.test.ts
+++ b/test/CreditLine.test.ts
@@ -466,6 +466,40 @@ describe("Contract 'CreditLine'", async () => {
     await proveTx(fixture.creditLineUnderAdmin[FUNC_CONFIGURE_BORROWER_NEW](borrower.address, borrowerConfigNew));
   }
 
+  async function executeAndCheckLoanOpeningHook(functionSignature: string, borrowingPolicy: BorrowingPolicy) {
+    const fixture = await setUpFixture(deployAndConfigureContractsWithBorrower);
+    const { creditLine, creditLineUnderAdmin } = fixture;
+    const loanState: LoanState = await prepareLoan(market);
+    const expectedBorrowerConfig = { ...fixture.borrowerConfig, borrowingPolicy };
+    const borrowedAmount = loanState.borrowedAmount;
+    const expectedBorrowerState: BorrowerState = { ...defaultBorrowerState };
+    if (borrowingPolicy === BorrowingPolicy.SingleActiveLoan) {
+      expectedBorrowerState.activeLoanCount = 0n;
+      expectedBorrowerState.closedLoanCount = maxUintForBits(16) - 1n;
+      expectedBorrowerState.totalActiveLoanAmount = 0n;
+      expectedBorrowerState.totalActiveLoanAmount = maxUintForBits(64) - borrowedAmount;
+    } else {
+      expectedBorrowerState.activeLoanCount = maxUintForBits(16) - 2n;
+      expectedBorrowerState.closedLoanCount = 1n;
+      expectedBorrowerState.totalActiveLoanAmount = maxUintForBits(64) - borrowedAmount * 2n;
+      expectedBorrowerState.totalActiveLoanAmount = borrowedAmount;
+    }
+    if (borrowingPolicy == BorrowingPolicy.TotalActiveAmountLimit) {
+      expectedBorrowerState.totalActiveLoanAmount = BigInt(expectedBorrowerConfig.maxBorrowedAmount) - borrowedAmount;
+    }
+    await proveTx(creditLineUnderAdmin[FUNC_CONFIGURE_BORROWER_NEW](borrower.address, expectedBorrowerConfig));
+    await proveTx(creditLineUnderAdmin.setBorrowerState(borrower.address, expectedBorrowerState));
+
+    await proveTx(market[functionSignature](getAddress(creditLine), LOAN_ID));
+
+    expectedBorrowerState.activeLoanCount += 1n;
+    expectedBorrowerState.totalActiveLoanAmount += BigInt(loanState.borrowedAmount);
+    const actualBorrowerState: BorrowerState = await creditLine.getBorrowerState(borrower.address);
+    checkEquality(actualBorrowerState, expectedBorrowerState);
+    const actualBorrowerConfig: BorrowerConfig = await creditLine.getBorrowerConfiguration(borrower.address);
+    checkEquality(actualBorrowerConfig, expectedBorrowerConfig);
+  }
+
   describe("Function 'initialize()'", async () => {
     it("Configures the contract as expected", async () => {
       const { creditLine } = await setUpFixture(deployContracts);
@@ -1147,29 +1181,25 @@ describe("Contract 'CreditLine'", async () => {
   });
 
   describe("Function 'onBeforeLoanTaken()'", async () => {
-    it("Executes as expected", async () => {
-      const fixture = await setUpFixture(deployAndConfigureContractsWithBorrower);
-      const { creditLine, creditLineUnderAdmin, borrowerConfig: expectedBorrowerConfig } = fixture;
-      const expectedBorrowerState: BorrowerState = {
-        ...defaultBorrowerState,
-        activeLoanCount: maxUintForBits(16) - 2n,
-        closedLoanCount: 1n,
-        totalActiveLoanAmount: maxUintForBits(64) - BigInt(BORROWED_AMOUNT * 2n),
-        totalClosedLoanAmount: BigInt(BORROWED_AMOUNT)
-      };
+    it("Executes as expected if the borrowing policy is 'SingleActiveLoan'", async () => {
+      await executeAndCheckLoanOpeningHook(
+        "callOnBeforeLoanTakenCreditLine(address,uint256)",
+        BorrowingPolicy.SingleActiveLoan
+      );
+    });
 
-      await proveTx(creditLineUnderAdmin[FUNC_CONFIGURE_BORROWER_NEW](borrower.address, expectedBorrowerConfig));
-      await proveTx(creditLineUnderAdmin.setBorrowerState(borrower.address, expectedBorrowerState));
-      const loanState: LoanState = await prepareLoan(market);
+    it("Executes as expected if the borrowing policy is 'MultipleActiveLoan'", async () => {
+      await executeAndCheckLoanOpeningHook(
+        "callOnBeforeLoanTakenCreditLine(address,uint256)",
+        BorrowingPolicy.MultipleActiveLoans
+      );
+    });
 
-      await proveTx(market.callOnBeforeLoanTakenCreditLine(getAddress(creditLine), LOAN_ID));
-
-      expectedBorrowerState.activeLoanCount += 1n;
-      expectedBorrowerState.totalActiveLoanAmount += BigInt(loanState.borrowedAmount);
-      const actualBorrowerState: BorrowerState = await creditLine.getBorrowerState(borrower.address);
-      checkEquality(actualBorrowerState, expectedBorrowerState);
-      const actualBorrowerConfig: BorrowerConfig = await creditLine.getBorrowerConfiguration(borrower.address);
-      checkEquality(actualBorrowerConfig, expectedBorrowerConfig);
+    it("Executes as expected if the borrowing policy is 'TotalActiveAmountLimit'", async () => {
+      await executeAndCheckLoanOpeningHook(
+        "callOnBeforeLoanTakenCreditLine(address,uint256)",
+        BorrowingPolicy.TotalActiveAmountLimit
+      );
     });
 
     it("Is reverted if the caller is not the configured market", async () => {
@@ -1185,6 +1215,39 @@ describe("Contract 'CreditLine'", async () => {
 
       await expect(market.callOnBeforeLoanTakenCreditLine(getAddress(creditLine), LOAN_ID))
         .to.be.revertedWithCustomError(creditLine, ERROR_NAME_ENFORCED_PAUSED);
+    });
+
+    it("Is reverted if the borrowing policy is 'SingleActiveLoan' but there is another active loan", async () => {
+      const fixture = await setUpFixture(deployAndConfigureContractsWithBorrower);
+      const { creditLine, creditLineUnderAdmin, borrowerConfig } = fixture;
+      await prepareLoan(market);
+      const borrowerConfigNew = { ...borrowerConfig, borrowingPolicy: BorrowingPolicy.SingleActiveLoan };
+      const borrowerState: BorrowerState = {
+        ...defaultBorrowerState,
+        activeLoanCount: 1n
+      };
+      await proveTx(creditLineUnderAdmin[FUNC_CONFIGURE_BORROWER_NEW](borrower.address, borrowerConfigNew));
+      await proveTx(creditLineUnderAdmin.setBorrowerState(borrower.address, borrowerState));
+
+      await expect(market.callOnBeforeLoanTakenCreditLine(getAddress(creditLine), LOAN_ID))
+        .to.revertedWithCustomError(creditLine, ERROR_NAME_LIMIT_VIOLATION_ON_SINGLE_ACTIVE_LOAN);
+    });
+
+    it("Is reverted if the borrowing policy is 'TotalActiveAmountLimit' but total amount excess happens", async () => {
+      const fixture = await setUpFixture(deployAndConfigureContractsWithBorrower);
+      const { creditLine, creditLineUnderAdmin, borrowerConfig } = fixture;
+      const loanState: LoanState = await prepareLoan(market);
+      const borrowerConfigNew = { ...borrowerConfig, borrowingPolicy: BorrowingPolicy.TotalActiveAmountLimit };
+      const borrowerState: BorrowerState = {
+        ...defaultBorrowerState,
+        totalActiveLoanAmount: borrowerConfig.maxBorrowedAmount - loanState.borrowedAmount + 1n
+      };
+      await proveTx(creditLineUnderAdmin[FUNC_CONFIGURE_BORROWER_NEW](borrower.address, borrowerConfigNew));
+      await proveTx(creditLineUnderAdmin.setBorrowerState(borrower.address, borrowerState));
+
+      await expect(market.callOnBeforeLoanTakenCreditLine(getAddress(creditLine), LOAN_ID))
+        .to.revertedWithCustomError(creditLine, ERROR_NAME_LIMIT_VIOLATION_ON_TOTAL_ACTIVE_LOAN_AMOUNT)
+        .withArgs(borrowerState.totalActiveLoanAmount + BigInt(BORROWED_AMOUNT));
     });
 
     it("Is reverted if the result total number of loans is greater than 16-bit unsigned integer", async () => {
@@ -1304,22 +1367,19 @@ describe("Contract 'CreditLine'", async () => {
   });
 
   describe("Function 'determineLoanTerms()'", async () => {
-    async function executeAndCheck(borrowingPolicy: BorrowingPolicy) {
+    it("Executes as expected even if the borrowing policy is violated", async () => {
       const fixture = await setUpFixture(deployAndConfigureContractsWithBorrower);
       const { creditLine, creditLineUnderAdmin } = fixture;
-      const borrowerConfig = { ...fixture.borrowerConfig, borrowingPolicy };
+      const borrowerConfig = { ...fixture.borrowerConfig, borrowingPolicy: BorrowingPolicy.TotalActiveAmountLimit };
       const borrowedAmount = (borrowerConfig.minBorrowedAmount + borrowerConfig.maxBorrowedAmount) / 2n;
       const durationInPeriods = (borrowerConfig.minDurationInPeriods + borrowerConfig.maxDurationInPeriods) / 2n;
       const borrowerState: BorrowerState = {
         ...defaultBorrowerState,
-        activeLoanCount: borrowingPolicy == BorrowingPolicy.SingleActiveLoan ? 0n : maxUintForBits(16),
+        activeLoanCount: maxUintForBits(16),
         closedLoanCount: maxUintForBits(16),
         totalActiveLoanAmount: maxUintForBits(64),
         totalClosedLoanAmount: maxUintForBits(64)
       };
-      if (borrowingPolicy == BorrowingPolicy.TotalActiveAmountLimit) {
-        borrowerState.totalActiveLoanAmount = BigInt(borrowerConfig.maxBorrowedAmount) - BigInt(borrowedAmount);
-      }
       await proveTx(creditLineUnderAdmin[FUNC_CONFIGURE_BORROWER_NEW](borrower.address, borrowerConfig));
       await proveTx(creditLineUnderAdmin.setBorrowerState(borrower.address, borrowerState));
 
@@ -1331,18 +1391,6 @@ describe("Contract 'CreditLine'", async () => {
       );
 
       checkEquality(actualTerms, expectedTerms);
-    }
-
-    it("Executes as expected if the borrowing policy is 'SingleActiveLoan'", async () => {
-      await executeAndCheck(BorrowingPolicy.SingleActiveLoan);
-    });
-
-    it("Executes as expected if the borrowing policy is 'MultipleActiveLoan'", async () => {
-      await executeAndCheck(BorrowingPolicy.MultipleActiveLoans);
-    });
-
-    it("Executes as expected if the borrowing policy is 'TotalActiveAmountLimit'", async () => {
-      await executeAndCheck(BorrowingPolicy.TotalActiveAmountLimit);
     });
 
     it("Is reverted if the borrower address is zero", async () => {
@@ -1412,45 +1460,6 @@ describe("Contract 'CreditLine'", async () => {
         borrowerConfig.minBorrowedAmount, // borrowedAmount
         borrowerConfig.maxDurationInPeriods + 1n // durationInPeriods
       )).to.be.revertedWithCustomError(creditLine, ERROR_NAME_LOAN_DURATION_OUT_OF_RANGE);
-    });
-
-    it("Is reverted if the borrowing policy is 'SingleActiveLoan' but there is another active loan", async () => {
-      const fixture = await setUpFixture(deployAndConfigureContractsWithBorrower);
-      const { creditLine, creditLineUnderAdmin, borrowerConfig } = fixture;
-      const borrowerConfigNew = { ...borrowerConfig, borrowingPolicy: BorrowingPolicy.SingleActiveLoan };
-      const borrowerState: BorrowerState = {
-        ...defaultBorrowerState,
-        activeLoanCount: 1n
-      };
-      await proveTx(creditLineUnderAdmin[FUNC_CONFIGURE_BORROWER_NEW](borrower.address, borrowerConfigNew));
-      await proveTx(creditLineUnderAdmin.setBorrowerState(borrower.address, borrowerState));
-
-      await expect(creditLine.determineLoanTerms(
-        borrower.address,
-        borrowerConfig.minBorrowedAmount, // borrowedAmount
-        borrowerConfig.minDurationInPeriods // durationInPeriods
-      )).to.revertedWithCustomError(creditLine, ERROR_NAME_LIMIT_VIOLATION_ON_SINGLE_ACTIVE_LOAN);
-    });
-
-    it("Is reverted if the borrowing policy is 'TotalActiveAmountLimit' but total amount excess happens", async () => {
-      const fixture = await setUpFixture(deployAndConfigureContractsWithBorrower);
-      const { creditLine, creditLineUnderAdmin, borrowerConfig } = fixture;
-      const borrowerConfigNew = { ...borrowerConfig, borrowingPolicy: BorrowingPolicy.TotalActiveAmountLimit };
-      const borrowerState: BorrowerState = {
-        ...defaultBorrowerState,
-        totalActiveLoanAmount: borrowerConfig.maxBorrowedAmount - BORROWED_AMOUNT + 1n
-      };
-      await proveTx(creditLineUnderAdmin[FUNC_CONFIGURE_BORROWER_NEW](borrower.address, borrowerConfigNew));
-      await proveTx(creditLineUnderAdmin.setBorrowerState(borrower.address, borrowerState));
-
-      await expect(creditLine.determineLoanTerms(
-        borrower.address,
-        BORROWED_AMOUNT,
-        borrowerConfig.minDurationInPeriods // durationInPeriods
-      )).to.revertedWithCustomError(
-        creditLine,
-        ERROR_NAME_LIMIT_VIOLATION_ON_TOTAL_ACTIVE_LOAN_AMOUNT
-      ).withArgs(borrowerState.totalActiveLoanAmount + BigInt(BORROWED_AMOUNT));
     });
   });
 

--- a/test/LendingMarket.base.test.ts
+++ b/test/LendingMarket.base.test.ts
@@ -221,8 +221,8 @@ const DURATIONS_IN_PERIODS: number[] = [0, DURATION_IN_PERIODS / 2, DURATION_IN_
 
 const EXPECTED_VERSION: Version = {
   major: 1,
-  minor: 11,
-  patch: 1
+  minor: 12,
+  patch: 0
 };
 
 const defaultLoanState: LoanState = {

--- a/test/LendingMarket.base.test.ts
+++ b/test/LendingMarket.base.test.ts
@@ -14,8 +14,6 @@ import {
   proveTx
 } from "../test-utils/eth";
 import { checkEquality, maxUintForBits, roundMath, setUpFixture } from "../test-utils/common";
-import { Rule } from "eslint";
-import Fix = Rule.Fix;
 
 enum LoanType {
   Ordinary = 0,
@@ -2475,6 +2473,7 @@ describe("Contract 'LendingMarket': base tests", async () => {
         const repaymentAmount = operations[operationToUndoIndex].amount === FULL_REPAYMENT_AMOUNT
           ? firstLoanTrackedBalanceBeforeRepayments[operationToUndoIndex]
           : operations[operationToUndoIndex].amount;
+        const roundedRepaymentAmount = roundSpecific(repaymentAmount);
         const repaymentTimestamp = calculateTimestampWithOffset(actualTimestamps[operationToUndoIndex]);
         const tx =
           marketUnderAdmin.undoRepaymentFor(loans[0].id, repaymentAmount, repaymentTimestamp, receiverAddress);
@@ -2500,7 +2499,7 @@ describe("Contract 'LendingMarket': base tests", async () => {
           await expect(tx).to.changeTokenBalances(
             token,
             [liquidityPool, borrower, receiver, marketUnderAdmin],
-            [-repaymentAmount, 0, repaymentAmount, 0]
+            [-roundedRepaymentAmount, 0, +roundedRepaymentAmount, 0]
           );
 
           await expect(tx)
@@ -3124,7 +3123,7 @@ describe("Contract 'LendingMarket': base tests", async () => {
         await expect(tx).to.changeTokenBalances(
           token,
           [liquidityPool, borrower, receiver, marketUnderAdmin],
-          [-repaymentAmount, 0, repaymentAmount, 0]
+          [-roundedRepaymentAmount, 0, roundedRepaymentAmount, 0]
         );
       }
 

--- a/test/LiquidityPool.test.ts
+++ b/test/LiquidityPool.test.ts
@@ -69,8 +69,8 @@ const REPAYMENT_AMOUNT = BORROWED_AMOUNT / 5n;
 const LOAN_ID = 123n;
 const EXPECTED_VERSION: Version = {
   major: 1,
-  minor: 11,
-  patch: 1
+  minor: 12,
+  patch: 0
 };
 
 const defaultLoanState: LoanState = {


### PR DESCRIPTION
## Main changes
1. The ability to undo repayments of fully repaid loans has been added.
2. The `undoRepaymentFor()` function can now accept unrounded `repaymentAmount` parameter values. This change has been introduce to properly undo final repayments of loans. The final repayment is one that caused closing of a loan.
3. To properly undo a final repayment the caller must provide the tracked balance of the loan before the repayment instead of the final repayment amount. To get the right tracked balance the following steps should be used:
    * a. Determine the block of the final repayment: `B`.
    * b. Determine the timestamp of the `B` block:  `BT`.
    * c. Determine the timestamp in the timezone of the lending contract: `BTZ`. E.g. for `America/Sao_Paulo` timezone: `BTZ = BT - 3 * 60 * 60`.
    * d. Call the `getLoanPreview()` function at the `B-1` block with the `BTZ` timestamp: `getLoanPreview(loanId, BTZ)`.
    * e. Use the `trackedBalance` field of the returned structure as the `repaymentAmount` parameter of the `undoRepaymentFor()` function to undo the final repayment.
4. The recommended algorithm for selecting the value of parameter `repaymentAmount` of function `undoRepaymentFor()`:
    * a. If the being undone repayment is NOT a final one use its repayment amount as the value.
    * b. Otherwise the repayment is a final one and so use the tracked balance of the loan before the repayment as the value. See the previous point for details.
5. The new `onBeforeLoanReopened()` hook function has been added to the credit line smart contract. It is called when a final repayment is being undone to check the loan can be reopened according to the current borrowing policy. If the loan cannot be reopened (e.g. the `maxBorrowedAmount` limit of all loans of the borrower is reached) the function will be returned with an appropriate error and the whole blockchain transaction will be reverted as well.

## Versioning

The smart contracts version has been updated to `v1.12.0`.

## Test Coverage

The new changes have been fully covered by tests.

<details>

<summary>Test coverage details</summary>

| File                                    |  % Stmts | % Branch |  % Funcs |  % Lines |
|-----------------------------------------|---------:|---------:|---------:|---------:|
| contracts/                              |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLine.sol                       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineStorage.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarket.sol                    |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketStorage.sol             |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPool.sol                    |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPoolStorage.sol             |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/base/                         |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeable.sol      |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ PausableExtUpgradeable.sol           |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ UUPSExtUpgradeable.sol               |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Versionable.sol                      |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/interfaces/                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICreditLine.sol                      |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICreditLineTypes.sol                 |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILendingMarket.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILiquidityPool.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ IVersionable.sol                     |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/libraries/                    |   100.00 |    98.00 |   100.00 |   100.00 |
| ├─ ABDKMath64x64.sol                    |   100.00 |    97.73 |   100.00 |   100.00 |
| ├─ Constants.sol                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Error.sol                            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ InterestMath.sol                     |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Loan.sol                             |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Rounding.sol                         |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ SafeCast.sol                         |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/mocks/                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ABDKMath64x64Mock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeableMock.sol  |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineMock.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ERC20Mock.sol                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketMock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPoolMock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ PausableExtUpgradeableMock.sol       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ RoundingMock.sol                     |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ UUPSExtUpgradableMock.sol            |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/testables/                    |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineTestable.sol               |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketTestable.sol            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPoolTestable.sol            |   100.00 |   100.00 |   100.00 |   100.00 |
|-----------------------------------------|----------|----------|----------|----------|
| All files                               |   100.00 |    99.80 |   100.00 |   100.00 |
|-----------------------------------------|----------|----------|----------|----------|

</details>
