### PR TITLE
feat: introduce operational treasury and admin role for pools

### DIFF
--- a/contracts/LiquidityPool.sol
+++ b/contracts/LiquidityPool.sol
@@ -156,8 +156,8 @@ contract LiquidityPool is
     }
 
     /// @inheritdoc ILiquidityPoolConfiguration
-    function setExternalTreasury(address newTreasury) external onlyRole(OWNER_ROLE) {
-        _setExternalTreasury(newTreasury);
+    function setOperationalTreasury(address newTreasury) external onlyRole(OWNER_ROLE) {
+        _setOperationalTreasury(newTreasury);
     }
 
     /// @dev Initializes the admin role for already deployed contracts.
@@ -178,8 +178,8 @@ contract LiquidityPool is
     }
 
     /// @inheritdoc ILiquidityPoolPrimary
-    function depositFromExternalTreasury(uint256 amount) external onlyRole(ADMIN_ROLE) {
-        _deposit(amount, _getAndCheckExternalTreasury());
+    function depositFromOperationalTreasury(uint256 amount) external onlyRole(ADMIN_ROLE) {
+        _deposit(amount, _getAndCheckOperationalTreasury());
     }
 
     /// @inheritdoc ILiquidityPoolPrimary
@@ -188,8 +188,8 @@ contract LiquidityPool is
     }
 
     /// @inheritdoc ILiquidityPoolPrimary
-    function withdrawToExternalTreasury(uint256 amount) external onlyRole(ADMIN_ROLE) {
-        _withdraw(amount, 0, _getAndCheckExternalTreasury());
+    function withdrawToOperationalTreasury(uint256 amount) external onlyRole(ADMIN_ROLE) {
+        _withdraw(amount, 0, _getAndCheckOperationalTreasury());
     }
 
     /// @inheritdoc ILiquidityPoolPrimary
@@ -254,8 +254,8 @@ contract LiquidityPool is
     }
 
     /// @inheritdoc ILiquidityPoolPrimary
-    function externalTreasury() external view returns (address) {
-        return _externalTreasury;
+    function operationalTreasury() external view returns (address) {
+        return _operationalTreasury;
     }
 
     /// @inheritdoc ILiquidityPoolPrimary
@@ -343,29 +343,29 @@ contract LiquidityPool is
         _addonTreasury = newTreasury;
     }
 
-    /// @dev Sets the new address of the external treasury internally.
-    /// @param newTreasury The new address of the external treasury.
-    function _setExternalTreasury(address newTreasury) internal {
-        address oldTreasury = _externalTreasury;
+    /// @dev Sets the new address of the operational treasury internally.
+    /// @param newTreasury The new address of the operational treasury.
+    function _setOperationalTreasury(address newTreasury) internal {
+        address oldTreasury = _operationalTreasury;
         if (oldTreasury == newTreasury) {
             revert Error.AlreadyConfigured();
         }
         if (newTreasury != address(0)) {
             if (IERC20(_token).allowance(newTreasury, address(this)) == 0) {
-                revert ExternalTreasuryZeroAllowanceForPool();
+                revert OperationalTreasuryZeroAllowanceForPool();
             }
         }
-        emit ExternalTreasuryChanged(newTreasury, oldTreasury);
-        _externalTreasury = newTreasury;
+        emit OperationalTreasuryChanged(newTreasury, oldTreasury);
+        _operationalTreasury = newTreasury;
     }
 
-    /// @dev Returns the external treasury address and validates it.
-    function _getAndCheckExternalTreasury() internal view returns (address) {
-        address externalTreasury_ = _externalTreasury;
-        if (externalTreasury_ == address(0)) {
-            revert ExternalTreasuryAddressZero();
+    /// @dev Returns the operational treasury address and validates it.
+    function _getAndCheckOperationalTreasury() internal view returns (address) {
+        address operationalTreasury_ = _operationalTreasury;
+        if (operationalTreasury_ == address(0)) {
+            revert OperationalTreasuryAddressZero();
         }
-        return externalTreasury_;
+        return operationalTreasury_;
     }
 
     /// @dev The upgrade validation function for the UUPSExtUpgradeable contract.

--- a/contracts/LiquidityPool.sol
+++ b/contracts/LiquidityPool.sol
@@ -333,7 +333,7 @@ contract LiquidityPool is
     }
 
     /// @dev Sets the new address of the external treasury internally.
-    /// @param newTreasury The new address of the external treasury.    
+    /// @param newTreasury The new address of the external treasury.
     function _setExternalTreasury(address newTreasury) internal {
         address oldTreasury = _externalTreasury;
         if (oldTreasury == newTreasury) {

--- a/contracts/LiquidityPool.sol
+++ b/contracts/LiquidityPool.sol
@@ -43,6 +43,8 @@ contract LiquidityPool is
 
     /// @dev The role of this contract owner.
     bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+    /// @dev The role of this contract admin.
+    bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
 
     // -------------------------------------------- //
     //  Modifiers                                   //
@@ -137,6 +139,7 @@ contract LiquidityPool is
         }
 
         _setRoleAdmin(OWNER_ROLE, OWNER_ROLE);
+        _setRoleAdmin(ADMIN_ROLE, OWNER_ROLE);
         _grantRole(OWNER_ROLE, owner_);
 
         _market = market_;
@@ -157,6 +160,14 @@ contract LiquidityPool is
         _setExternalTreasury(newTreasury);
     }
 
+    /// @dev Initializes the admin role for already deployed contracts.
+    ///
+    /// This function can be removed after the admin role is initialized in all deployed contracts.
+    function initAdminRole() external onlyRole(OWNER_ROLE) {
+        _setRoleAdmin(ADMIN_ROLE, OWNER_ROLE);
+        _grantRole(ADMIN_ROLE, msg.sender);
+    }
+
     // -------------------------------------------- //
     //  Primary transactional functions             //
     // -------------------------------------------- //
@@ -167,7 +178,7 @@ contract LiquidityPool is
     }
 
     /// @inheritdoc ILiquidityPoolPrimary
-    function depositFromExternalTreasury(uint256 amount) external onlyRole(OWNER_ROLE) {
+    function depositFromExternalTreasury(uint256 amount) external onlyRole(ADMIN_ROLE) {
         _deposit(amount, _getAndCheckExternalTreasury());
     }
 
@@ -177,7 +188,7 @@ contract LiquidityPool is
     }
 
     /// @inheritdoc ILiquidityPoolPrimary
-    function withdrawToExternalTreasury(uint256 amount) external onlyRole(OWNER_ROLE) {
+    function withdrawToExternalTreasury(uint256 amount) external onlyRole(ADMIN_ROLE) {
         _withdraw(amount, 0, _getAndCheckExternalTreasury());
     }
 

--- a/contracts/LiquidityPoolStorage.sol
+++ b/contracts/LiquidityPoolStorage.sol
@@ -29,7 +29,12 @@ abstract contract LiquidityPoolStorage {
     /// Now the addon amount must always be output to an external wallet. The addon balance of the pool is always zero.
     address internal _addonTreasury;
 
+    /// @dev The address of the external treasury.
+    ///
+    /// The external treasury is used to deposit and withdraw tokens by special functions.
+    address internal _externalTreasury;
+
     /// @dev This empty reserved space is put in place to allow future versions
     /// to add new variables without shifting down storage in the inheritance chain.
-    uint256[46] private __gap;
+    uint256[45] private __gap;
 }

--- a/contracts/LiquidityPoolStorage.sol
+++ b/contracts/LiquidityPoolStorage.sol
@@ -29,10 +29,10 @@ abstract contract LiquidityPoolStorage {
     /// Now the addon amount must always be output to an external wallet. The addon balance of the pool is always zero.
     address internal _addonTreasury;
 
-    /// @dev The address of the external treasury.
+    /// @dev The address of the operational treasury.
     ///
-    /// The external treasury is used to deposit and withdraw tokens through special functions.
-    address internal _externalTreasury;
+    /// The operational treasury is used to deposit and withdraw tokens through special functions.
+    address internal _operationalTreasury;
 
     /// @dev This empty reserved space is put in place to allow future versions
     /// to add new variables without shifting down storage in the inheritance chain.

--- a/contracts/LiquidityPoolStorage.sol
+++ b/contracts/LiquidityPoolStorage.sol
@@ -31,7 +31,7 @@ abstract contract LiquidityPoolStorage {
 
     /// @dev The address of the external treasury.
     ///
-    /// The external treasury is used to deposit and withdraw tokens by special functions.
+    /// The external treasury is used to deposit and withdraw tokens through special functions.
     address internal _externalTreasury;
 
     /// @dev This empty reserved space is put in place to allow future versions

--- a/contracts/base/Versionable.sol
+++ b/contracts/base/Versionable.sol
@@ -10,6 +10,6 @@ import "../interfaces/IVersionable.sol";
 abstract contract Versionable is IVersionable {
     /// @inheritdoc IVersionable
     function $__VERSION() external pure returns (Version memory) {
-        return Version(1, 12, 0);
+        return Version(1, 13, 0);
     }
 }

--- a/contracts/interfaces/ILiquidityPool.sol
+++ b/contracts/interfaces/ILiquidityPool.sol
@@ -72,7 +72,7 @@ interface ILiquidityPoolPrimary {
 
     /// @dev Returns the external treasury address.
     ///
-    /// The external treasury is used to deposit and withdraw tokens by special functions.
+    /// The external treasury is used to deposit and withdraw tokens through special functions.
     ///
     /// @return The current address of the external treasury.
     function externalTreasury() external view returns (address);

--- a/contracts/interfaces/ILiquidityPool.sol
+++ b/contracts/interfaces/ILiquidityPool.sol
@@ -32,9 +32,9 @@ interface ILiquidityPoolPrimary {
     /// @param amount The amount of tokens to deposit.
     function deposit(uint256 amount) external;
 
-    /// @dev Deposits tokens to the liquidity pool from the external treasury.
+    /// @dev Deposits tokens to the liquidity pool from the operational treasury.
     /// @param amount The amount of tokens to deposit.
-    function depositFromExternalTreasury(uint256 amount) external;
+    function depositFromOperationalTreasury(uint256 amount) external;
 
     /// @dev Withdraws tokens from the liquidity pool to the caller account.
     /// @param borrowableAmount The amount of tokens to withdraw from the borrowable balance.
@@ -42,9 +42,9 @@ interface ILiquidityPoolPrimary {
     ///        See the {addonTreasury} function comments for more details.
     function withdraw(uint256 borrowableAmount, uint256 addonAmount) external;
 
-    /// @dev Withdraws tokens from the liquidity pool to the external treasury.
+    /// @dev Withdraws tokens from the liquidity pool to the operational treasury.
     /// @param amount The amount of tokens to withdraw from the borrowable balance.
-    function withdrawToExternalTreasury(uint256 amount) external;
+    function withdrawToOperationalTreasury(uint256 amount) external;
 
     /// @dev Rescues tokens from the liquidity pool.
     /// @param token The address of the token to rescue.
@@ -70,12 +70,12 @@ interface ILiquidityPoolPrimary {
     /// @return The current address of the addon treasury.
     function addonTreasury() external view returns (address);
 
-    /// @dev Returns the external treasury address.
+    /// @dev Returns the operational treasury address.
     ///
-    /// The external treasury is used to deposit and withdraw tokens through special functions.
+    /// The operational treasury is used to deposit and withdraw tokens through special functions.
     ///
-    /// @return The current address of the external treasury.
-    function externalTreasury() external view returns (address);
+    /// @return The current address of the operational treasury.
+    function operationalTreasury() external view returns (address);
 
     /// @dev Gets the borrowable and addons balances of the liquidity pool.
     ///
@@ -104,13 +104,13 @@ interface ILiquidityPoolConfiguration {
     /// @param oldTreasury The previous address of the addon treasury.
     event AddonTreasuryChanged(address newTreasury, address oldTreasury);
 
-    /// @dev Emitted when the external treasury address has been changed.
+    /// @dev Emitted when the operational treasury address has been changed.
     ///
-    /// See the {externalTreasury} function comments for more details.
+    /// See the {operationalTreasury} function comments for more details.
     ///
-    /// @param newTreasury The updated address of the external treasury.
-    /// @param oldTreasury The previous address of the external treasury.
-    event ExternalTreasuryChanged(address newTreasury, address oldTreasury);
+    /// @param newTreasury The updated address of the operational treasury.
+    /// @param oldTreasury The previous address of the operational treasury.
+    event OperationalTreasuryChanged(address newTreasury, address oldTreasury);
 
     // -------------------------------------------- //
     //  Transactional functions                     //
@@ -123,12 +123,12 @@ interface ILiquidityPoolConfiguration {
     /// @param newTreasury The new address of the addon treasury to set.
     function setAddonTreasury(address newTreasury) external;
 
-    /// @dev Sets the external treasury address.
+    /// @dev Sets the operational treasury address.
     ///
-    /// See the {externalTreasury} function comments for more details.
+    /// See the {operationalTreasury} function comments for more details.
     ///
-    /// @param newTreasury The new address of the external treasury to set.
-    function setExternalTreasury(address newTreasury) external;
+    /// @param newTreasury The new address of the operational treasury to set.
+    function setOperationalTreasury(address newTreasury) external;
 }
 
 /// @title ILiquidityPoolHooks interface
@@ -168,14 +168,14 @@ interface ILiquidityPoolErrors {
     /// @dev Thrown when the addon treasury has not provided an allowance for the lending market to transfer its tokens.
     error AddonTreasuryZeroAllowanceForMarket();
 
-    /// @dev Thrown when the external treasury address is zero.
-    error ExternalTreasuryAddressZero();
-
-    /// @dev Thrown when the external treasury has not provided an allowance for the pool to transfer its tokens.
-    error ExternalTreasuryZeroAllowanceForPool();
-
     /// @dev Thrown when the token source balance is insufficient.
     error InsufficientBalance();
+
+    /// @dev Thrown when the operational treasury address is zero.
+    error OperationalTreasuryAddressZero();
+
+    /// @dev Thrown when the operational treasury has not provided an allowance for the pool to transfer its tokens.
+    error OperationalTreasuryZeroAllowanceForPool();
 }
 
 /// @title ILiquidityPool interface

--- a/contracts/interfaces/ILiquidityPool.sol
+++ b/contracts/interfaces/ILiquidityPool.sol
@@ -28,15 +28,23 @@ interface ILiquidityPoolPrimary {
     //  Transactional functions                     //
     // -------------------------------------------- //
 
-    /// @dev Deposits tokens to the liquidity pool.
+    /// @dev Deposits tokens to the liquidity pool from the caller account.
     /// @param amount The amount of tokens to deposit.
     function deposit(uint256 amount) external;
 
-    /// @dev Withdraws tokens from the liquidity pool.
+    /// @dev Deposits tokens to the liquidity pool from the external treasury.
+    /// @param amount The amount of tokens to deposit.
+    function depositFromExternalTreasury(uint256 amount) external;
+
+    /// @dev Withdraws tokens from the liquidity pool to the caller account.
     /// @param borrowableAmount The amount of tokens to withdraw from the borrowable balance.
     /// @param addonAmount This parameter has been deprecated since version 1.8.0 and must be zero.
     ///        See the {addonTreasury} function comments for more details.
     function withdraw(uint256 borrowableAmount, uint256 addonAmount) external;
+
+    /// @dev Withdraws tokens from the liquidity pool to the external treasury.
+    /// @param amount The amount of tokens to withdraw from the borrowable balance.
+    function withdrawToExternalTreasury(uint256 amount) external;
 
     /// @dev Rescues tokens from the liquidity pool.
     /// @param token The address of the token to rescue.
@@ -62,6 +70,13 @@ interface ILiquidityPoolPrimary {
     /// @return The current address of the addon treasury.
     function addonTreasury() external view returns (address);
 
+    /// @dev Returns the external treasury address.
+    ///
+    /// The external treasury is used to deposit and withdraw tokens by special functions.
+    ///
+    /// @return The current address of the external treasury.
+    function externalTreasury() external view returns (address);
+
     /// @dev Gets the borrowable and addons balances of the liquidity pool.
     ///
     /// The addons part of the balance has been deprecated since version 1.8.0 and now it always equals zero.
@@ -81,13 +96,21 @@ interface ILiquidityPoolConfiguration {
     //  Events                                      //
     // -------------------------------------------- //
 
-    /// @dev Emitted when the the addon treasury address has been changed.
+    /// @dev Emitted when the addon treasury address has been changed.
     ///
     /// See the {addonTreasury} function comments for more details.
     ///
     /// @param newTreasury The updated address of the addon treasury.
     /// @param oldTreasury The previous address of the addon treasury.
     event AddonTreasuryChanged(address newTreasury, address oldTreasury);
+
+    /// @dev Emitted when the external treasury address has been changed.
+    ///
+    /// See the {externalTreasury} function comments for more details.
+    ///
+    /// @param newTreasury The updated address of the external treasury.
+    /// @param oldTreasury The previous address of the external treasury.
+    event ExternalTreasuryChanged(address newTreasury, address oldTreasury);
 
     // -------------------------------------------- //
     //  Transactional functions                     //
@@ -99,6 +122,13 @@ interface ILiquidityPoolConfiguration {
     ///
     /// @param newTreasury The new address of the addon treasury to set.
     function setAddonTreasury(address newTreasury) external;
+
+    /// @dev Sets the external treasury address.
+    ///
+    /// See the {externalTreasury} function comments for more details.
+    ///
+    /// @param newTreasury The new address of the external treasury to set.
+    function setExternalTreasury(address newTreasury) external;
 }
 
 /// @title ILiquidityPoolHooks interface
@@ -137,6 +167,12 @@ interface ILiquidityPoolErrors {
 
     /// @dev Thrown when the addon treasury has not provided an allowance for the lending market to transfer its tokens.
     error AddonTreasuryZeroAllowanceForMarket();
+
+    /// @dev Thrown when the external treasury address is zero.
+    error ExternalTreasuryAddressZero();
+
+    /// @dev Thrown when the external treasury has not provided an allowance for the pool to transfer its tokens.
+    error ExternalTreasuryZeroAllowanceForPool();
 
     /// @dev Thrown when the token source balance is insufficient.
     error InsufficientBalance();

--- a/contracts/testables/LiquidityPoolTestable.sol
+++ b/contracts/testables/LiquidityPoolTestable.sol
@@ -33,4 +33,11 @@ contract LiquidityPoolTestable is LiquidityPool {
     ) public {
         __LiquidityPool_init_unchained(lender_, market_, token_);
     }
+
+    /// @dev Sets the admin role for a given role for testing purposes.
+    /// @param role The role to set the admin for.
+    /// @param adminRole The admin role to set.
+    function setRoleAdmin(bytes32 role, bytes32 adminRole) external {
+        _setRoleAdmin(role, adminRole);
+    }
 }

--- a/test-utils/specific.ts
+++ b/test-utils/specific.ts
@@ -1,0 +1,13 @@
+export interface Version {
+  major: number;
+  minor: number;
+  patch: number;
+
+  [key: string]: number; // Indexing signature to ensure that fields are iterated over in a key-value style
+}
+
+export const EXPECTED_VERSION: Version = {
+  major: 1,
+  minor: 13,
+  patch: 0
+};

--- a/test/CreditLine.test.ts
+++ b/test/CreditLine.test.ts
@@ -11,6 +11,7 @@ import {
   proveTx
 } from "../test-utils/eth";
 import { checkEquality, maxUintForBits, setUpFixture } from "../test-utils/common";
+import { EXPECTED_VERSION } from "../test-utils/specific";
 
 enum BorrowingPolicy {
   SingleActiveLoan = 0,
@@ -110,14 +111,6 @@ interface LoanState {
   installmentCount: bigint;
   lateFeeAmount: bigint;
   discountAmount: bigint;
-}
-
-interface Version {
-  major: number;
-  minor: number;
-  patch: number;
-
-  [key: string]: number; // Indexing signature to ensure that fields are iterated over in a key-value style
 }
 
 interface Fixture {
@@ -256,12 +249,6 @@ const FUNC_DETERMINE_LATE_FEE_AMOUNT_NEW =
   "determineLateFeeAmount(address,uint256)";
 const FUNC_DETERMINE_LATE_FEE_AMOUNT_LEGACY =
   "determineLateFeeAmount(uint256)";
-
-const EXPECTED_VERSION: Version = {
-  major: 1,
-  minor: 12,
-  patch: 0
-};
 
 function processLoanClosing(borrowerState: BorrowerState, borrowedAmount: bigint) {
   borrowerState.activeLoanCount -= 1n;

--- a/test/LendingMarket.base.test.ts
+++ b/test/LendingMarket.base.test.ts
@@ -14,6 +14,7 @@ import {
   proveTx
 } from "../test-utils/eth";
 import { checkEquality, maxUintForBits, roundMath, setUpFixture } from "../test-utils/common";
+import { EXPECTED_VERSION } from "../test-utils/specific";
 
 enum LoanType {
   Ordinary = 0,
@@ -117,14 +118,6 @@ interface Fixture {
   installmentLoanParts: Loan[];
 }
 
-interface Version {
-  major: number;
-  minor: number;
-  patch: number;
-
-  [key: string]: number; // Indexing signature to ensure that fields are iterated over in a key-value style
-}
-
 enum PayerKind {
   Borrower = 0,
   Stranger = 1
@@ -218,12 +211,6 @@ const INSTALLMENT_COUNT = 3;
 const BORROWED_AMOUNTS: number[] = [BORROWED_AMOUNT * 3 - 1, BORROWED_AMOUNT * 2 + 1, BORROWED_AMOUNT];
 const ADDON_AMOUNTS: number[] = [ADDON_AMOUNT * 3 - 1, ADDON_AMOUNT * 2 + 1, ADDON_AMOUNT];
 const DURATIONS_IN_PERIODS: number[] = [0, DURATION_IN_PERIODS / 2, DURATION_IN_PERIODS];
-
-const EXPECTED_VERSION: Version = {
-  major: 1,
-  minor: 12,
-  patch: 0
-};
 
 const defaultLoanState: LoanState = {
   programId: 0,

--- a/test/LiquidityPool.test.ts
+++ b/test/LiquidityPool.test.ts
@@ -4,6 +4,7 @@ import { Contract, ContractFactory, TransactionResponse } from "ethers";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
 import { checkContractUupsUpgrading, connect, deployAndConnectContract, getAddress, proveTx } from "../test-utils/eth";
 import { checkEquality, maxUintForBits, setUpFixture } from "../test-utils/common";
+import { EXPECTED_VERSION } from "../test-utils/specific";
 
 interface LoanState {
   programId: bigint;
@@ -23,14 +24,6 @@ interface LoanState {
   installmentCount: bigint;
   lateFeeAmount: bigint;
   discountAmount: bigint;
-}
-
-interface Version {
-  major: number;
-  minor: number;
-  patch: number;
-
-  [key: string]: number; // Indexing signature to ensure that fields are iterated over in a key-value style
 }
 
 const ERROR_NAME_ACCESS_CONTROL_UNAUTHORIZED = "AccessControlUnauthorizedAccount";
@@ -76,11 +69,6 @@ const BORROWED_AMOUNT = DEPOSIT_AMOUNT / 10n;
 const ADDON_AMOUNT = BORROWED_AMOUNT / 10n;
 const REPAYMENT_AMOUNT = BORROWED_AMOUNT / 5n;
 const LOAN_ID = 123n;
-const EXPECTED_VERSION: Version = {
-  major: 1,
-  minor: 12,
-  patch: 0
-};
 
 const defaultLoanState: LoanState = {
   programId: 0n,


### PR DESCRIPTION
## Main changes.
1. The operational treasury has been introduced on the liquidity pool smart contract to simplify managing its borrowable balance through special new functions.
2. The admin role has been reintroduced to the liquidity pool smart contract. Accounts with that roles can execute the new functions to deposit and withdraw tokens using the operation treasury account configured on the contract.

    <details>
    
    <summary>The new role definition </summary>
    
    ```solidity
    /// @dev The role of this contract admin.
    bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
    ```
    
    </details>

3. The new pool balance management functions are `depositFromOperationalTreasury()` and `withdrawToOperationalTreasury()`:

    <details>
    
    <summary>The definition of new functions </summary>
    
    ```solidity
    /// @dev Deposits tokens to the liquidity pool from the operational treasury.
    /// @param amount The amount of tokens to deposit.
    function depositFromOperationalTreasury(uint256 amount) external onlyRole(ADMIN_ROLE) {...}
    
    /// @dev Withdraws tokens from the liquidity pool to the operational treasury.
    /// @param amount The amount of tokens to withdraw from the borrowable balance.
    function withdrawToOperationalTreasury(uint256 amount) external onlyRole(ADMIN_ROLE) {....}
    ```
    
    </details>

4. The token flows for the new pool balance management functions:
    * `depositFromOperationalTreasury()`: `operationTreasury` => `liquidityPool`;
    * `withdrawToOperationalTreasury()`:  `liquidityPool` => `operationTreasury`;
    * no other balances are changed.

5. No additional events have been introduced for the new pool balance management functions. The existing `Deposit` and `Withdrawal` events are emitted by the new functions.

6. New functions `setOperationalTreasury()` and `operationalTreasury()` have been introduced to set and get the address of the operational treasury on the liquidity pool smart contract:

    <details>
    
    <summary>The definition of new functions </summary>
    
    ```solidity
    /// @dev Sets the operational treasury address.
    ///
    /// See the {operationalTreasury} function comments for more details.
    ///
    /// @param newTreasury The new address of the operational treasury to set.
    function setOperationalTreasury(address newTreasury) external onlyRole(OWNER_ROLE) {....}
    
    /// @dev Returns the operational treasury address.
    ///
    /// The operational treasury is used to deposit and withdraw tokens through special functions.
    ///
    /// @return The current address of the operational treasury.
    function operationalTreasury() external view returns (address) {....}
    ```
    
    </details>

7. The new `OperationalTreasuryChanged` event has been introduced to the liquidity pool smart contract. The new event  is emitted when the operational treasury address is changed:

    <details>
    
    <summary>The new event definition</summary>
    
    ```solidity
    /// @dev Emitted when the operational treasury address has been changed.
    ///
    /// See the {operationalTreasury} function comments for more details.
    ///
    /// @param newTreasury The updated address of the operational treasury.
    /// @param oldTreasury The previous address of the operational treasury.
    event OperationalTreasuryChanged(address newTreasury, address oldTreasury);
    ```
    
    </details>

## Versioning

The smart contracts version has been updated to `v1.13.0`.

## Migration Steps

After upgrading the `CapybaraFinance` smart-contracts call the `LiquidityPool.initAdminRole()` function without parameters once from an account with the owner role. It will initialize the admin role and grant it to the caller.

## Test Coverage

The new changes have been fully covered by tests.

<details>

<summary>Test coverage details</summary>

| File                                    |  % Stmts | % Branch |  % Funcs |  % Lines |
|-----------------------------------------|---------:|---------:|---------:|---------:|
| contracts/                              |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLine.sol                       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineStorage.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarket.sol                    |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketStorage.sol             |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPool.sol                    |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPoolStorage.sol             |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/base/                         |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeable.sol      |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ PausableExtUpgradeable.sol           |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ UUPSExtUpgradeable.sol               |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Versionable.sol                      |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/interfaces/                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICreditLine.sol                      |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICreditLineTypes.sol                 |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILendingMarket.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILiquidityPool.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ IVersionable.sol                     |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/libraries/                    |   100.00 |    98.00 |   100.00 |   100.00 |
| ├─ ABDKMath64x64.sol                    |   100.00 |    97.73 |   100.00 |   100.00 |
| ├─ Constants.sol                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Error.sol                            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ InterestMath.sol                     |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Loan.sol                             |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Rounding.sol                         |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ SafeCast.sol                         |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/mocks/                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ABDKMath64x64Mock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeableMock.sol  |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineMock.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ERC20Mock.sol                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketMock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPoolMock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ PausableExtUpgradeableMock.sol       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ RoundingMock.sol                     |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ UUPSExtUpgradableMock.sol            |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/testables/                    |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineTestable.sol               |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketTestable.sol            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPoolTestable.sol            |   100.00 |   100.00 |   100.00 |   100.00 |
|-----------------------------------------|----------|----------|----------|----------|
| All files                               |   100.00 |    99.80 |   100.00 |   100.00 |
|-----------------------------------------|----------|----------|----------|----------|

</details>
