### PR TITLE
feat: the new deposit and withdrawal functions with reserve for pools

### DIFF
--- a/contracts/LiquidityPool.sol
+++ b/contracts/LiquidityPool.sol
@@ -15,7 +15,7 @@ import { Loan } from "./libraries/Loan.sol";
 import { SafeCast } from "./libraries/SafeCast.sol";
 
 import { ICreditLine } from "./interfaces/ICreditLine.sol";
-import { IERC20ReserveMintable } from "./interfaces/IERC20ReserveMintable.sol";
+import {IERC20Mintable} from "./interfaces/IERC20Mintable.sol";
 import { ILendingMarket } from "./interfaces/ILendingMarket.sol";
 import { ILiquidityPool } from "./interfaces/ILiquidityPool.sol";
 import { ILiquidityPoolConfiguration } from "./interfaces/ILiquidityPool.sol";
@@ -185,7 +185,7 @@ contract LiquidityPool is
 
     /// @inheritdoc ILiquidityPoolPrimary
     function depositFromReserve(uint256 amount) external onlyRole(ADMIN_ROLE) {
-        IERC20ReserveMintable(_token).mintFromReserve(address(this), amount);
+        IERC20Mintable(_token).mintFromReserve(address(this), amount);
         _deposit(amount, address(this));
     }
 
@@ -202,7 +202,7 @@ contract LiquidityPool is
     /// @inheritdoc ILiquidityPoolPrimary
     function withdrawToReserve(uint256 amount) external onlyRole(ADMIN_ROLE) {
         _withdraw(amount, 0, address(this));
-        IERC20ReserveMintable(_token).burnToReserve(amount);
+        IERC20Mintable(_token).burnToReserve(amount);
     }
 
     /// @inheritdoc ILiquidityPoolPrimary

--- a/contracts/base/Versionable.sol
+++ b/contracts/base/Versionable.sol
@@ -10,6 +10,6 @@ import "../interfaces/IVersionable.sol";
 abstract contract Versionable is IVersionable {
     /// @inheritdoc IVersionable
     function $__VERSION() external pure returns (Version memory) {
-        return Version(1, 13, 0);
+        return Version(1, 14, 0);
     }
 }

--- a/contracts/interfaces/IERC20Mintable.sol
+++ b/contracts/interfaces/IERC20Mintable.sol
@@ -2,10 +2,10 @@
 
 pragma solidity ^0.8.0;
 
-/// @title IERC20ReserveMintable interface
+/// @title IERC20Mintable interface
 /// @author CloudWalk Inc. (See https://cloudwalk.io)
-/// @dev The interface of a special token smart contract that can mint and burn tokens using the reserve.
-interface IERC20ReserveMintable {
+/// @dev The interface of an ERC20 token smart contract that supports minting and burning tokens.
+interface IERC20Mintable {
     /// @dev Mints tokens from reserve.
     ///
     /// Tokens are minted in a regular way, but we also increase the total reserve supply by the minted amount.

--- a/contracts/interfaces/IERC20ReserveMintable.sol
+++ b/contracts/interfaces/IERC20ReserveMintable.sol
@@ -6,26 +6,18 @@ pragma solidity ^0.8.0;
 /// @author CloudWalk Inc. (See https://cloudwalk.io)
 /// @dev The interface of a special token smart contract that can mint and burn tokens using the reserve.
 interface IERC20ReserveMintable {
-    // -------------------------------------------- //
-    //  Transactional functions                     //
-    // -------------------------------------------- //
-
-    /**
-     * @dev Mints tokens from reserve.
-     *
-     * Tokens are minted in a regular way, but we also increase the total reserve supply by the amount of tokens minted.
-     *
-     * @param account The address of a tokens recipient
-     * @param amount The amount of tokens to mint
-     */
+    /// @dev Mints tokens from reserve.
+    ///
+    /// Tokens are minted in a regular way, but we also increase the total reserve supply by the minted amount.
+    ///
+    /// @param account The address of a tokens recipient
+    /// @param amount The amount of tokens to mint
     function mintFromReserve(address account, uint256 amount) external;
 
-    /**
-     * @dev Burns tokens to reserve.
-     *
-     * Tokens are burned in a regular way, but we also decrease the total reserve supply by the amount of tokens burned.
-     *
-     * @param amount The amount of tokens to burn
-     */
+    /// @dev Burns tokens to reserve.
+    ///
+    /// Tokens are burned in a regular way, but we also decrease the total reserve supply by the burned amount.
+    ///
+    /// @param amount The amount of tokens to burn
     function burnToReserve(uint256 amount) external;
 }

--- a/contracts/interfaces/IERC20ReserveMintable.sol
+++ b/contracts/interfaces/IERC20ReserveMintable.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/// @title IERC20ReserveMintable interface
+/// @author CloudWalk Inc. (See https://cloudwalk.io)
+/// @dev The interface of a special token smart contract that can mint and burn tokens using the reserve.
+interface IERC20ReserveMintable {
+    // -------------------------------------------- //
+    //  Transactional functions                     //
+    // -------------------------------------------- //
+
+    /**
+     * @dev Mints tokens from reserve.
+     *
+     * Tokens are minted in a regular way, but we also increase the total reserve supply by the amount of tokens minted.
+     *
+     * @param account The address of a tokens recipient
+     * @param amount The amount of tokens to mint
+     */
+    function mintFromReserve(address account, uint256 amount) external;
+
+    /**
+     * @dev Burns tokens to reserve.
+     *
+     * Tokens are burned in a regular way, but we also decrease the total reserve supply by the amount of tokens burned.
+     *
+     * @param amount The amount of tokens to burn
+     */
+    function burnToReserve(uint256 amount) external;
+}

--- a/contracts/interfaces/ILiquidityPool.sol
+++ b/contracts/interfaces/ILiquidityPool.sol
@@ -36,6 +36,11 @@ interface ILiquidityPoolPrimary {
     /// @param amount The amount of tokens to deposit.
     function depositFromOperationalTreasury(uint256 amount) external;
 
+    /// @dev Deposits tokens to the liquidity pool by minting them from the reserve
+    ///      using a special function of the token smart-contract.
+    /// @param amount The amount of tokens to mint and deposit.
+    function depositFromReserve(uint256 amount) external;
+
     /// @dev Withdraws tokens from the liquidity pool to the caller account.
     /// @param borrowableAmount The amount of tokens to withdraw from the borrowable balance.
     /// @param addonAmount This parameter has been deprecated since version 1.8.0 and must be zero.
@@ -45,6 +50,11 @@ interface ILiquidityPoolPrimary {
     /// @dev Withdraws tokens from the liquidity pool to the operational treasury.
     /// @param amount The amount of tokens to withdraw from the borrowable balance.
     function withdrawToOperationalTreasury(uint256 amount) external;
+
+    /// @dev Withdraws tokens from the liquidity pool by burning them to the reserve
+    //       using a special function of the token smart-contract.
+    /// @param amount The amount of tokens to withdraw from the borrowable balance and burn.
+    function withdrawToReserve(uint256 amount) external;
 
     /// @dev Rescues tokens from the liquidity pool.
     /// @param token The address of the token to rescue.

--- a/contracts/interfaces/ILiquidityPool.sol
+++ b/contracts/interfaces/ILiquidityPool.sol
@@ -37,7 +37,10 @@ interface ILiquidityPoolPrimary {
     function depositFromOperationalTreasury(uint256 amount) external;
 
     /// @dev Deposits tokens to the liquidity pool by minting them from the reserve
-    ///      using a special function of the token smart-contract.
+    ///      using a special function of the underlying token smart-contract.
+    ///
+    /// To use this function this contract must be granted an appropriate role on the token contract.
+    ///
     /// @param amount The amount of tokens to mint and deposit.
     function depositFromReserve(uint256 amount) external;
 
@@ -52,7 +55,10 @@ interface ILiquidityPoolPrimary {
     function withdrawToOperationalTreasury(uint256 amount) external;
 
     /// @dev Withdraws tokens from the liquidity pool by burning them to the reserve
-    //       using a special function of the token smart-contract.
+    //       using a special function of the underlying token smart-contract.
+    ///
+    /// To use this function this contract must be granted an appropriate role on the token contract.
+    ///
     /// @param amount The amount of tokens to withdraw from the borrowable balance and burn.
     function withdrawToReserve(uint256 amount) external;
 

--- a/contracts/mocks/ERC20Mock.sol
+++ b/contracts/mocks/ERC20Mock.sol
@@ -2,19 +2,74 @@
 
 pragma solidity 0.8.24;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+import { IERC20ReserveMintable } from "../interfaces/IERC20ReserveMintable.sol";
 
 /// @title ERC20Mock contract
 /// @author CloudWalk Inc. (See https://cloudwalk.io)
 /// @dev Mock of the `ERC20` token contract used for testing.
-contract ERC20Mock is ERC20 {
+contract ERC20Mock is ERC20, IERC20ReserveMintable {
+    // -------------------------------------------- //
+    //  Events                                      //
+    // -------------------------------------------- //
+
+    /// @dev Emitted when the minting of tokens from the reserve is imitated.
+    ///
+    /// @param sender The address of the sender.
+    /// @param account The address of the account to mint tokens to.
+    /// @param amount The amount of tokens to mint.
+    event MockMintingFromReserve(
+        address sender, // Tools: this comment prevents Prettier from formatting into a single line.
+        address account,
+        uint256 amount
+    );
+
+    /// @dev Emitted when the burning of tokens to the reserve is imitated.
+    ///
+    /// @param sender The address of the sender.
+    /// @param amount The amount of tokens to burn.
+    event MockBurningToReserve(
+        address sender, // Tools: this comment prevents Prettier from formatting into a single line.
+        uint256 amount
+    );
+
+    // -------------------------------------------- //
+    //  Constructor                                 //
+    // -------------------------------------------- //
+
     /// @dev Contract constructor.
     constructor() ERC20("NAME", "SYMBOL") {}
 
+    // -------------------------------------------- //
+    //  Transactional functions                     //
+    // -------------------------------------------- //
+
     /// @dev Mints tokens.
-    /// @param to The address to mint tokens to.
+    /// @param account The address to mint tokens to.
     /// @param amount The amount of tokens to mint.
-    function mint(address to, uint256 amount) external {
-        _mint(to, amount);
+    function mint(address account, uint256 amount) external {
+        _mint(account, amount);
+    }
+
+    /// @dev Imitates minting tokens from reserve.
+    ///
+    /// Executes the regular minting process and emits the event about mock minting from reserve.
+    ///
+    /// @param account The address to mint tokens to.
+    /// @param amount The amount of tokens to mint.
+    function mintFromReserve(address account, uint256 amount) external {
+        _mint(account, amount);
+        emit MockMintingFromReserve(msg.sender, account, amount);
+    }
+
+    /// @dev Imitates burning tokens to reserve.
+    ///
+    /// Executes the regular burning process and emits the event about mock burning to reserve.
+    ///
+    /// @param amount The amount of tokens to burn.
+    function burnToReserve(uint256 amount) external {
+        _burn(msg.sender, amount);
+        emit MockBurningToReserve(msg.sender, amount);
     }
 }

--- a/contracts/mocks/ERC20Mock.sol
+++ b/contracts/mocks/ERC20Mock.sol
@@ -4,12 +4,12 @@ pragma solidity 0.8.24;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-import { IERC20ReserveMintable } from "../interfaces/IERC20ReserveMintable.sol";
+import {IERC20Mintable} from "../interfaces/IERC20Mintable.sol";
 
 /// @title ERC20Mock contract
 /// @author CloudWalk Inc. (See https://cloudwalk.io)
 /// @dev Mock of the `ERC20` token contract used for testing.
-contract ERC20Mock is ERC20, IERC20ReserveMintable {
+contract ERC20Mock is ERC20, IERC20Mintable {
     // -------------------------------------------- //
     //  Events                                      //
     // -------------------------------------------- //

--- a/test-utils/specific.ts
+++ b/test-utils/specific.ts
@@ -8,6 +8,6 @@ export interface Version {
 
 export const EXPECTED_VERSION: Version = {
   major: 1,
-  minor: 13,
+  minor: 14,
   patch: 0
 };


### PR DESCRIPTION
## Main changes
1. The new `depositFromReserve()` and `withdrawToReserve()` functions have been introduced in the liquidity pool smart contract to manage its balance:
    <details>
    
    <summary>The definition of new functions </summary>
    
    ```solidity
    /// @dev Withdraws tokens from the liquidity pool by burning them to the reserve
    //       using a special function of the underlying token smart-contract.
    ///
    /// To use this function this contract must be granted an appropriate role on the token contract.
    ///
    /// @param amount The amount of tokens to withdraw from the borrowable balance and burn.
        function depositFromReserve(uint256 amount) external onlyRole(ADMIN_ROLE) {....}
    
    /// @dev Withdraws tokens from the liquidity pool to the operational treasury.
    /// @param amount The amount of tokens to withdraw from the borrowable balance.
    function withdrawToReserve(uint256 amount) external onlyRole(ADMIN_ROLE) {....}
    ```
    
    </details>

2. The `depositFromReserve()` function first mints tokens from the reserve on the underlying token smart-contract and puts them into the pool account, then deposits them into the pool.

3. The `withdrawToReserve()` function first withdraws tokens from the pool but keeps them on the pool account, then burns the tokens to the reserve on the underlying token smart-contract.

4. Both new functions can be called only by an account that has the admin role with the hash: `bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE")`.

5. The token flows for the new functions:
    * `depositFromReserve()`: `address(0)` => `pool`;
    * `withdrawToReserve()`:  `pool` => `address(0)`;
    * no other balances are changed.

6. The list of events generated by the `depositFromReserve()` function when the BRLC token is used as an underlying one:
    * `Mint(minter=address(pool), account=address(pool), amount)` from the BRLC token smart contract;
    * `Transfer(from=address(0), to=address(pool), amount)` from the BRLC token smart contract;
    * `MintFromReserve(minter=address(pool), to=address(pool), amount, newReserveSupply)` from the BRLC token smart contract;
    * `Deposit(amount)` from the liquidity pool smart-contract.

7. The list of events generated by the `withdrawToReserve()` function when the BRLC token is used as an underlying one:
    * `Withdrawal(borrowableAmount=amount, addonAmount=0)` from the liquidity pool smart-contract;
    * `Burn(burner=address(pool), amount)` from the BRLC token smart contract;
    * `Transfer(from=address(pool), to=address(0), amount)` from the BRLC token smart contract;
    * `BurnToReserve(burner=address(pool), amount, newReserveSupply)` from the BRLC token smart contract.

## Versioning

The smart contracts version has been updated to `v1.14.0`.

## Test Coverage

The new changes have been fully covered by tests.

<details>

<summary>Test coverage details</summary>

| File                                    |  % Stmts | % Branch |  % Funcs |  % Lines |
|-----------------------------------------|---------:|---------:|---------:|---------:|
| contracts/                              |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLine.sol                       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineStorage.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarket.sol                    |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketStorage.sol             |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPool.sol                    |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPoolStorage.sol             |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/base/                         |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeable.sol      |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ PausableExtUpgradeable.sol           |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ UUPSExtUpgradeable.sol               |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Versionable.sol                      |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/interfaces/                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICreditLine.sol                      |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ICreditLineTypes.sol                 |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ IERC20ReserveMintable.sol            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILendingMarket.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ILiquidityPool.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ IVersionable.sol                     |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/libraries/                    |   100.00 |    98.00 |   100.00 |   100.00 |
| ├─ ABDKMath64x64.sol                    |   100.00 |    97.73 |   100.00 |   100.00 |
| ├─ Constants.sol                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Error.sol                            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ InterestMath.sol                     |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Loan.sol                             |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ Rounding.sol                         |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ SafeCast.sol                         |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/mocks/                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ABDKMath64x64Mock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ AccessControlExtUpgradeableMock.sol  |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineMock.sol                   |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ ERC20Mock.sol                        |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketMock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPoolMock.sol                |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ PausableExtUpgradeableMock.sol       |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ RoundingMock.sol                     |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ UUPSExtUpgradableMock.sol            |   100.00 |   100.00 |   100.00 |   100.00 |
| contracts/testables/                    |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ CreditLineTestable.sol               |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LendingMarketTestable.sol            |   100.00 |   100.00 |   100.00 |   100.00 |
| ├─ LiquidityPoolTestable.sol            |   100.00 |   100.00 |   100.00 |   100.00 |
|-----------------------------------------|----------|----------|----------|----------|
| All files                               |   100.00 |    99.80 |   100.00 |   100.00 |
|-----------------------------------------|----------|----------|----------|----------|

</details>

