### PR TITLE
chore: comment ipmrovements

### DIFF
--- a/.cursor/rules/solidity-example-project.mdc
+++ b/.cursor/rules/solidity-example-project.mdc
@@ -1037,7 +1037,7 @@ contract AccessControlExtUpgradeableMock is AccessControlExtUpgradeable, UUPSUpg
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */
@@ -1090,7 +1090,7 @@ contract PausableExtUpgradeableMock is PausableExtUpgradeable, UUPSUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */
@@ -1143,7 +1143,7 @@ contract RescuableUpgradeableMock is RescuableUpgradeable, UUPSUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */
@@ -1199,7 +1199,7 @@ contract UUPSExtUpgradeableMock is UUPSExtUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */

--- a/.cursor/rules/solidity-example-project.mdc
+++ b/.cursor/rules/solidity-example-project.mdc
@@ -422,7 +422,7 @@ abstract contract AccessControlExtUpgradeable is AccessControlUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The unchained internal initializer of the upgradeable contract
+     * @dev The unchained internal initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/contracts/5.x/upgradeable#multiple-inheritance
      *
@@ -503,7 +503,7 @@ abstract contract PausableExtUpgradeable is AccessControlExtUpgradeable, Pausabl
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The unchained internal initializer of the upgradeable contract
+     * @dev The unchained internal initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/contracts/5.x/upgradeable#multiple-inheritance
      *
@@ -565,7 +565,7 @@ abstract contract RescuableUpgradeable is AccessControlExtUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The unchained internal initializer of the upgradeable contract
+     * @dev The unchained internal initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/contracts/5.x/upgradeable#multiple-inheritance
      *

--- a/.cursor/rules/solidity-example-project.mdc
+++ b/.cursor/rules/solidity-example-project.mdc
@@ -352,7 +352,7 @@ abstract contract BlueprintStorageLayout is IBlueprintTypes {
     /**
      * @dev Defines the contract storage structure.
      *
-     * The fields:
+     * Fields:
      *
      * - token ---------------- The address of the underlying token.
      * - operationalTreasury -- The address of the operational treasury.
@@ -938,7 +938,7 @@ interface IBlueprintTypes {
     /**
      * @dev The data of a single operation of the blueprint smart-contract.
      *
-     * The fields:
+     * Fields:
      *
      * - status --- The status of the operation according to the {OperationStatus} enum.
      * - account -- The address of the account involved in the operation.
@@ -954,7 +954,7 @@ interface IBlueprintTypes {
     /**
      * @dev The state of a single account within the blueprint smart-contract.
      *
-     * The fields:
+     * Fields:
      *
      * - lastOpId -------- The identifier of the last operation related to the account.
      * - balance --------- The balance of the account.
@@ -991,7 +991,7 @@ interface IVersionable {
     /**
      * @dev Defines the version of a contract.
      *
-     * The fields:
+     * Fields:
      *
      * - major -- The major version of the contract.
      * - minor -- The minor version of the contract.

--- a/.cursor/rules/solidity-example-project.mdc
+++ b/.cursor/rules/solidity-example-project.mdc
@@ -367,11 +367,11 @@ abstract contract BlueprintStorageLayout is IBlueprintTypes {
     struct BlueprintStorage {
         // Slot 1
         address token;
-        // uint96 __reserved1; // Reserved for future use until the end of the storage slot
+        // uint96 __reserved1; // Reserved until the end of the storage slot
 
         // Slot 2
         address operationalTreasury;
-        // uint96 __reserved2; // Reserved for future use until the end of the storage slot
+        // uint96 __reserved2; // Reserved until the end of the storage slot
 
         // Slot 3
         mapping(bytes32 opId => Operation operation) operations;
@@ -948,7 +948,7 @@ interface IBlueprintTypes {
         OperationStatus status;
         address account;
         uint64 amount;
-        // uint24 __reserved; // Reserved for future use until the end of the storage slot
+        // uint24 __reserved; // Reserved until the end of the storage slot
     }
 
     /**
@@ -968,7 +968,7 @@ interface IBlueprintTypes {
         // Slot 2
         uint64 balance;
         uint32 operationCount;
-        // uint160 __reserved; // Reserved for future use until the end of the storage slot
+        // uint160 __reserved; // Reserved until the end of the storage slot
     }
 }
 ```

--- a/.cursor/rules/solidity-rules.mdc
+++ b/.cursor/rules/solidity-rules.mdc
@@ -208,7 +208,7 @@ alwaysApply: false
      /**
       * @dev The data of a single operation of the blueprint smart-contract.
       *
-      * The fields:
+      * Fields:
       *
       * - status --- The status of the operation according to the {OperationStatus} enum.
       * - account -- The address of the account involved in the operation.

--- a/.cursor/rules/solidity-rules.mdc
+++ b/.cursor/rules/solidity-rules.mdc
@@ -218,7 +218,7 @@ alwaysApply: false
          uint8 status;
          address account;
          uint64 amount;
-         // uint24 __reserved; // Reserved for future use until the end of the storage slot
+         // uint24 __reserved; // Reserved until the end of the storage slot
      }
      ```
     
@@ -233,7 +233,7 @@ alwaysApply: false
         // Slot 2
         uint64 balance;
         uint32 operationCount;
-        // uint160 __reserved; // Reserved for future use until the end of the storage slot
+        // uint160 __reserved; // Reserved until the end of the storage slot
     }
     ```
 

--- a/contracts/CreditLine.sol
+++ b/contracts/CreditLine.sol
@@ -57,7 +57,7 @@ contract CreditLine is
     /**
      * @dev Constructor that prohibits the initialization of the implementation of the upgradeable contract.
      *
-     * See details
+     * See details:
      * https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable#initializing_the_implementation_contract
      *
      * @custom:oz-upgrades-unsafe-allow constructor
@@ -73,7 +73,7 @@ contract CreditLine is
      * @param owner_ The address of the credit line owner.
      * @param market_ The address of the lending market.
      * @param token_ The address of the token.
-     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     * See details https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable.
      */
     function initialize(
         address owner_, // Tools: this comment prevents Prettier from formatting into a single line.

--- a/contracts/CreditLine.sol
+++ b/contracts/CreditLine.sol
@@ -76,7 +76,7 @@ contract CreditLine is
      * See details https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable.
      */
     function initialize(
-        address owner_, // Tools: this comment prevents Prettier from formatting into a single line.
+        address owner_, // Tools: prevent Prettier one-liner
         address market_,
         address token_
     ) external initializer {

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -95,7 +95,7 @@ contract LendingMarket is
 
     /// @inheritdoc ILendingMarketConfiguration
     function createProgram(
-        address creditLine, // Tools: this comment prevents Prettier from formatting into a single line.
+        address creditLine, // Tools: prevent Prettier one-liner
         address liquidityPool
     ) external whenNotPaused onlyRole(OWNER_ROLE) {
         _checkCreditLineAndLiquidityPool(creditLine, liquidityPool);
@@ -117,7 +117,7 @@ contract LendingMarket is
 
     /// @inheritdoc ILendingMarketConfiguration
     function updateProgram(
-        uint32 programId, // Tools: this comment prevents Prettier from formatting into a single line.
+        uint32 programId, // Tools: prevent Prettier one-liner
         address creditLine,
         address liquidityPool
     ) external whenNotPaused onlyRole(OWNER_ROLE) {
@@ -147,7 +147,7 @@ contract LendingMarket is
     ) external whenNotPaused onlyRole(ADMIN_ROLE) returns (uint256) {
         _checkMainLoanParameters(borrower, programId, borrowedAmount, addonAmount);
         uint256 loanId = _takeLoan(
-            borrower, // Tools: this comment prevents Prettier from formatting into a single line.
+            borrower, // Tools: prevent Prettier one-liner
             programId,
             borrowedAmount,
             addonAmount,
@@ -182,7 +182,7 @@ contract LendingMarket is
                 revert Error.InvalidAmount();
             }
             uint256 loanId = _takeLoan(
-                borrower, // Tools: this comment prevents Prettier from formatting into a single line.
+                borrower, // Tools: prevent Prettier one-liner
                 programId,
                 borrowedAmounts[i],
                 addonAmounts[i],
@@ -264,7 +264,7 @@ contract LendingMarket is
         }
 
         emit InstallmentLoanRevoked(
-            loan.firstInstallmentId, // Tools: this comment prevents Prettier from formatting into a single line.
+            loan.firstInstallmentId, // Tools: prevent Prettier one-liner
             loan.installmentCount
         );
 
@@ -278,7 +278,7 @@ contract LendingMarket is
 
     /// @inheritdoc ILendingMarketPrimary
     function discountLoanForBatch(
-        uint256[] calldata loanIds, // Tools: this comment prevents Prettier from formatting into a single line.
+        uint256[] calldata loanIds, // Tools: prevent Prettier one-liner
         uint256[] calldata discountAmounts
     ) external whenNotPaused onlyRole(ADMIN_ROLE) {
         uint256 len = loanIds.length;
@@ -551,7 +551,7 @@ contract LendingMarket is
     ) external pure returns (uint256) {
         return
             InterestMath.calculateTrackedBalance(
-                originalBalance, // Tools: this comment prevents Prettier from formatting into a single line.
+                originalBalance, // Tools: prevent Prettier one-liner
                 numberOfPeriods,
                 interestRate,
                 interestRateFactor_
@@ -593,7 +593,7 @@ contract LendingMarket is
         _checkLoanId(id);
 
         Loan.Terms memory terms = ICreditLine(creditLine).determineLoanTerms(
-            borrower, // Tools: this comment prevents Prettier from formatting into a single line.
+            borrower, // Tools: prevent Prettier one-liner
             borrowedAmount,
             durationInPeriods
         );
@@ -630,7 +630,7 @@ contract LendingMarket is
      * @param repayer The token source for the repayment or zero if the source is the loan borrower themself.
      */
     function _repayLoan(
-        uint256 loanId, // Tools: this comment prevents Prettier from formatting into a single line.
+        uint256 loanId, // Tools: prevent Prettier one-liner
         uint256 repaymentAmount,
         address repayer
     ) internal {
@@ -674,7 +674,7 @@ contract LendingMarket is
      * @param discountAmount The amount of the discount.
      */
     function _discountLoan(
-        uint256 loanId, // Tools: this comment prevents Prettier from formatting into a single line.
+        uint256 loanId, // Tools: prevent Prettier one-liner
         uint256 discountAmount
     ) internal {
         uint256 newTrackedBalance;
@@ -816,7 +816,7 @@ contract LendingMarket is
      * @param installmentCount The total number of installments.
      */
     function _updateLoanInstallmentData(
-        uint256 loanId, // Tools: this comment prevents Prettier from formatting into a single line.
+        uint256 loanId, // Tools: prevent Prettier one-liner
         uint256 firstInstallmentId,
         uint256 installmentCount
     ) internal {
@@ -1125,7 +1125,7 @@ contract LendingMarket is
      * @return The late fee amount.
      */
     function _calculateLateFee(
-        uint256 trackedBalance, // Tools: this comment prevents Prettier from formatting into a single line.
+        uint256 trackedBalance, // Tools: prevent Prettier one-liner
         Loan.State storage loan
     ) internal view returns (uint256) {
         address creditLine = _programCreditLines[loan.programId];

--- a/contracts/LendingMarket.sol
+++ b/contracts/LendingMarket.sol
@@ -66,7 +66,7 @@ contract LendingMarket is
     /**
      * @dev Constructor that prohibits the initialization of the implementation of the upgradeable contract.
      *
-     * See details
+     * See details:
      * https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable#initializing_the_implementation_contract
      *
      * @custom:oz-upgrades-unsafe-allow constructor
@@ -80,7 +80,7 @@ contract LendingMarket is
     /**
      * @dev Initializer of the upgradeable contract.
      * @param owner_ The owner of the contract.
-     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     * See details https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable.
      */
     function initialize(address owner_) external initializer {
         __AccessControlExt_init_unchained();

--- a/contracts/LiquidityPool.sol
+++ b/contracts/LiquidityPool.sol
@@ -79,7 +79,7 @@ contract LiquidityPool is
      * See details https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable.
      */
     function initialize(
-        address owner_, // Tools: this comment prevents Prettier from formatting into a single line.
+        address owner_, // Tools: prevent Prettier one-liner
         address market_,
         address token_
     ) external initializer {

--- a/contracts/LiquidityPool.sol
+++ b/contracts/LiquidityPool.sol
@@ -60,7 +60,7 @@ contract LiquidityPool is
     /**
      * @dev Constructor that prohibits the initialization of the implementation of the upgradeable contract.
      *
-     * See details
+     * See details:
      * https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable#initializing_the_implementation_contract
      *
      * @custom:oz-upgrades-unsafe-allow constructor
@@ -76,7 +76,7 @@ contract LiquidityPool is
      * @param owner_ The address of the liquidity pool owner.
      * @param market_ The address of the lending market.
      * @param token_ The address of the token.
-     * See details https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable.
+     * See details https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable.
      */
     function initialize(
         address owner_, // Tools: this comment prevents Prettier from formatting into a single line.

--- a/contracts/base/PausableExtUpgradeable.sol
+++ b/contracts/base/PausableExtUpgradeable.sol
@@ -7,7 +7,7 @@ import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/P
 import { AccessControlExtUpgradeable } from "./AccessControlExtUpgradeable.sol";
 
 /**
- * @title PausableExtUpgradeable base contract.
+ * @title PausableExtUpgradeable base contract
  * @author CloudWalk Inc. (See https://www.cloudwalk.io)
  * @dev Extends the OpenZeppelin's {PausableUpgradeable} contract by adding the {PAUSER_ROLE} role and implementing
  *      the external pausing and unpausing functions.

--- a/contracts/interfaces/ICreditLineTypes.sol
+++ b/contracts/interfaces/ICreditLineTypes.sol
@@ -42,7 +42,7 @@ interface ICreditLineTypes {
     /**
      * @dev A struct that defines credit line configuration.
      *
-     * The fields:
+     * Fields:
      *
      * - minBorrowedAmount --------- The minimum amount of tokens the borrower can take as a loan.
      * - maxBorrowedAmount --------- The maximum amount of tokens the borrower can take as a loan.
@@ -83,7 +83,7 @@ interface ICreditLineTypes {
     /**
      * @dev A struct that defines borrower configuration.
      *
-     * The fields:
+     * Fields:
      *
      * - expiration ------------- The expiration date of the configuration.
      * - minDurationInPeriods --- The minimum duration of the loan determined in periods.
@@ -122,7 +122,7 @@ interface ICreditLineTypes {
     /**
      * @dev A legacy struct that defines borrower configuration.
      *
-     * The fields:
+     * Fields:
      *
      * - expiration ------------- The expiration date of the configuration.
      * - minDurationInPeriods --- The minimum duration of the loan determined in periods.
@@ -157,7 +157,7 @@ interface ICreditLineTypes {
     /**
      * @dev Defines a borrower state.
      *
-     * The fields:
+     * Fields:
      *
      * - activeLoanCount -------- the number of active loans currently held by the borrower.
      * - closedLoanCount -------- the number of loans that have been closed, with or without a full repayment.

--- a/contracts/interfaces/ICreditLineTypes.sol
+++ b/contracts/interfaces/ICreditLineTypes.sol
@@ -170,6 +170,6 @@ interface ICreditLineTypes {
         uint16 closedLoanCount;
         uint64 totalActiveLoanAmount;
         uint64 totalClosedLoanAmount;
-        // uint96 __reserved; // Reserved for future use until the end of the storage slot.
+        // uint96 __reserved; // Reserved until the end of the storage slot.
     }
 }

--- a/contracts/interfaces/ICreditLineTypes.sol
+++ b/contracts/interfaces/ICreditLineTypes.sol
@@ -42,7 +42,7 @@ interface ICreditLineTypes {
     /**
      * @dev A struct that defines credit line configuration.
      *
-     * Fields:
+     * The fields:
      *
      * - minBorrowedAmount --------- The minimum amount of tokens the borrower can take as a loan.
      * - maxBorrowedAmount --------- The maximum amount of tokens the borrower can take as a loan.
@@ -83,7 +83,7 @@ interface ICreditLineTypes {
     /**
      * @dev A struct that defines borrower configuration.
      *
-     * Fields:
+     * The fields:
      *
      * - expiration ------------- The expiration date of the configuration.
      * - minDurationInPeriods --- The minimum duration of the loan determined in periods.
@@ -122,7 +122,7 @@ interface ICreditLineTypes {
     /**
      * @dev A legacy struct that defines borrower configuration.
      *
-     * Fields:
+     * The fields:
      *
      * - expiration ------------- The expiration date of the configuration.
      * - minDurationInPeriods --- The minimum duration of the loan determined in periods.
@@ -157,7 +157,7 @@ interface ICreditLineTypes {
     /**
      * @dev Defines a borrower state.
      *
-     * Fields:
+     * The fields:
      *
      * - activeLoanCount -------- the number of active loans currently held by the borrower.
      * - closedLoanCount -------- the number of loans that have been closed, with or without a full repayment.

--- a/contracts/interfaces/ILendingMarket.sol
+++ b/contracts/interfaces/ILendingMarket.sol
@@ -39,7 +39,7 @@ interface ILendingMarketPrimary {
      * @param durationInPeriods The duration of the loan in periods.
      */
     event LoanTaken(
-        uint256 indexed loanId, // Tools: this comment prevents Prettier from formatting into a single line.
+        uint256 indexed loanId, // Tools: prevent Prettier one-liner
         address indexed borrower,
         uint256 principalAmount,
         uint256 durationInPeriods
@@ -91,7 +91,7 @@ interface ILendingMarketPrimary {
      * @param installmentCount The total number of installments.
      */
     event InstallmentLoanRevoked(
-        uint256 indexed firstInstallmentId, // Tools: this comment prevents Prettier from formatting into a single line.
+        uint256 indexed firstInstallmentId, // Tools: prevent Prettier one-liner
         uint256 installmentCount
     );
 
@@ -102,7 +102,7 @@ interface ILendingMarketPrimary {
      * @param newTrackedBalance The new tracked balance of the loan after the discount.
      */
     event LoanDiscounted(
-        uint256 indexed loanId, // Tools: this comment prevents Prettier from formatting into a single line.
+        uint256 indexed loanId, // Tools: prevent Prettier one-liner
         uint256 discountAmount,
         uint256 newTrackedBalance
     );
@@ -152,7 +152,7 @@ interface ILendingMarketPrimary {
      * @param oldDuration The old duration of the loan in periods.
      */
     event LoanDurationUpdated(
-        uint256 indexed loanId, // Tools: this comment prevents Prettier from formatting into a single line.
+        uint256 indexed loanId, // Tools: prevent Prettier one-liner
         uint256 indexed newDuration,
         uint256 indexed oldDuration
     );
@@ -266,7 +266,7 @@ interface ILendingMarketPrimary {
      * @param discountAmounts The amounts to discount for each loan in the batch.
      */
     function discountLoanForBatch(
-        uint256[] calldata loanIds, // Tools: this comment prevents Prettier from formatting into a single line.
+        uint256[] calldata loanIds, // Tools: prevent Prettier one-liner
         uint256[] calldata discountAmounts
     ) external;
 
@@ -330,7 +330,7 @@ interface ILendingMarketPrimary {
      * @param receiver The address of the receiver of the tokens due to the repayment undoing.
      */
     function undoRepaymentFor(
-        uint256 loanId, // Tools: this comment prevents Prettier from formatting into a single line.
+        uint256 loanId, // Tools: prevent Prettier one-liner
         uint256 repaymentAmount,
         uint256 repaymentTimestamp,
         address receiver
@@ -466,7 +466,7 @@ interface ILendingMarketConfiguration {
      * @param creditLine The address of the credit line registered.
      */
     event CreditLineRegistered(
-        address indexed lender, // Tools: this comment prevents Prettier from formatting into a single line.
+        address indexed lender, // Tools: prevent Prettier one-liner
         address indexed creditLine
     );
 
@@ -483,7 +483,7 @@ interface ILendingMarketConfiguration {
      *
      */
     event LiquidityPoolRegistered(
-        address indexed lender, // Tools: this comment prevents Prettier from formatting into a single line.
+        address indexed lender, // Tools: prevent Prettier one-liner
         address indexed liquidityPool
     );
 
@@ -493,7 +493,7 @@ interface ILendingMarketConfiguration {
      * @param programId The unique identifier of the program.
      */
     event ProgramCreated(
-        address indexed lender, // Tools: this comment prevents Prettier from formatting into a single line.
+        address indexed lender, // Tools: prevent Prettier one-liner
         uint32 indexed programId
     );
 
@@ -504,7 +504,7 @@ interface ILendingMarketConfiguration {
      * @param liquidityPool The address of the liquidity pool associated with the program.
      */
     event ProgramUpdated(
-        uint32 indexed programId, // Tools: this comment prevents Prettier from formatting into a single line.
+        uint32 indexed programId, // Tools: prevent Prettier one-liner
         address indexed creditLine,
         address indexed liquidityPool
     );
@@ -523,7 +523,7 @@ interface ILendingMarketConfiguration {
      * @param isAlias True if the account is configured as an alias, otherwise false.
      */
     event LenderAliasConfigured(
-        address indexed lender, // Tools: this comment prevents Prettier from formatting into a single line.
+        address indexed lender, // Tools: prevent Prettier one-liner
         address indexed account,
         bool isAlias
     );

--- a/contracts/interfaces/IVersionable.sol
+++ b/contracts/interfaces/IVersionable.sol
@@ -13,7 +13,7 @@ interface IVersionable {
     /**
      * @dev Defines the version of a contract.
      *
-     * The fields:
+     * Fields:
      *
      * - major -- The major version of the contract.
      * - minor -- The minor version of the contract.

--- a/contracts/libraries/Loan.sol
+++ b/contracts/libraries/Loan.sol
@@ -23,7 +23,8 @@ library Loan {
     /**
      * @dev A struct that defines the stored state of a loan.
      *
-     * Fields:
+     * The fields:
+     * 
      * - programId -------------- The unique identifier of the program.
      * - borrowedAmount --------- The initial borrowed amount of the loan, excluding the addon.
      * - addonAmount ------------ The amount of the loan addon (extra charges or fees).
@@ -74,7 +75,8 @@ library Loan {
     /**
      * @dev A struct that defines the terms of a loan.
      *
-     * Fields:
+     * The fields:
+     * 
      * - token ------------------ The address of the token to be used for the loan.
      * - addonAmount ------------ The amount of the loan addon (extra charges or fees).
      * - durationInPeriods ------ The total duration of the loan determined by the number of periods.
@@ -97,7 +99,8 @@ library Loan {
     /**
      * @dev A struct that defines the preview of the loan.
      *
-     * Fields:
+     * The fields:
+     * 
      * - periodIndex ------------ The period index that matches the preview timestamp.
      * - trackedBalance --------- The tracked balance of the loan at the previewed period.
      * - outstandingBalance ----- The outstanding balance of the loan at the previewed period.
@@ -114,7 +117,8 @@ library Loan {
     /**
      * @dev A struct that defines the extended preview of a loan.
      *
-     * Fields:
+     * The fields:
+     * 
      * - periodIndex ------------ The period index that matches the preview timestamp.
      * - trackedBalance --------- The tracked balance of the loan at the previewed period.
      * - outstandingBalance ----- The outstanding balance of the loan at the previewed period.

--- a/contracts/libraries/Loan.sol
+++ b/contracts/libraries/Loan.sol
@@ -23,7 +23,7 @@ library Loan {
     /**
      * @dev A struct that defines the stored state of a loan.
      *
-     * The fields:
+     * Fields:
      * 
      * - programId -------------- The unique identifier of the program.
      * - borrowedAmount --------- The initial borrowed amount of the loan, excluding the addon.
@@ -75,7 +75,7 @@ library Loan {
     /**
      * @dev A struct that defines the terms of a loan.
      *
-     * The fields:
+     * Fields:
      * 
      * - token ------------------ The address of the token to be used for the loan.
      * - addonAmount ------------ The amount of the loan addon (extra charges or fees).
@@ -99,7 +99,7 @@ library Loan {
     /**
      * @dev A struct that defines the preview of the loan.
      *
-     * The fields:
+     * Fields:
      * 
      * - periodIndex ------------ The period index that matches the preview timestamp.
      * - trackedBalance --------- The tracked balance of the loan at the previewed period.
@@ -117,7 +117,7 @@ library Loan {
     /**
      * @dev A struct that defines the extended preview of a loan.
      *
-     * The fields:
+     * Fields:
      * 
      * - periodIndex ------------ The period index that matches the preview timestamp.
      * - trackedBalance --------- The tracked balance of the loan at the previewed period.

--- a/contracts/mocks/AccessControlExtUpgradeableMock.sol
+++ b/contracts/mocks/AccessControlExtUpgradeableMock.sol
@@ -18,7 +18,7 @@ contract AccessControlExtUpgradeableMock is AccessControlExtUpgradeable, UUPSUpg
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */

--- a/contracts/mocks/ERC20Mock.sol
+++ b/contracts/mocks/ERC20Mock.sol
@@ -22,7 +22,7 @@ contract ERC20Mock is ERC20, IERC20Mintable {
      * @param amount The amount of tokens to mint.
      */
     event MockMintingFromReserve(
-        address sender, // Tools: this comment prevents Prettier from formatting into a single line.
+        address sender, // Tools: prevent Prettier one-liner
         address account,
         uint256 amount
     );
@@ -34,7 +34,7 @@ contract ERC20Mock is ERC20, IERC20Mintable {
      * @param amount The amount of tokens to burn.
      */
     event MockBurningToReserve(
-        address sender, // Tools: this comment prevents Prettier from formatting into a single line.
+        address sender, // Tools: prevent Prettier one-liner
         uint256 amount
     );
 

--- a/contracts/mocks/PausableExtUpgradeableMock.sol
+++ b/contracts/mocks/PausableExtUpgradeableMock.sol
@@ -15,7 +15,7 @@ contract PausableExtUpgradeableMock is PausableExtUpgradeable, UUPSUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */

--- a/contracts/mocks/UUPSExtUpgradeableMock.sol
+++ b/contracts/mocks/UUPSExtUpgradeableMock.sol
@@ -18,7 +18,7 @@ contract UUPSExtUpgradeableMock is UUPSExtUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */


### PR DESCRIPTION
# Main Changes

1. Fixed punctuation in NatSpec comments.
1. Standardized the comments for initializers, constructors. storage slots within structures.
1. Shortened the tool comments that prevents Prettier from formatting into a single line.

Issue:
https://github.com/cloudwalk/product-smart-contracts/issues/199
